### PR TITLE
Set model path to be relative to the model assembly

### DIFF
--- a/ml.net/InclusiveCodeReviews.Model/ConsumeModel.cs
+++ b/ml.net/InclusiveCodeReviews.Model/ConsumeModel.cs
@@ -18,7 +18,11 @@ namespace InclusiveCodeReviews.Model
     {
         private static Lazy<PredictionEngine<ModelInput, ModelOutput>> PredictionEngine = new Lazy<PredictionEngine<ModelInput, ModelOutput>>(CreatePredictionEngine);
 
-        public static string MLNetModelPath = Path.GetFullPath("MLModel.zip");
+        public static string MLNetModelPath =
+            Path.GetFullPath(
+                Path.Combine(
+                    Path.GetDirectoryName(typeof(ConsumeModel).Assembly.Location),
+                    "MLModel.zip"));
 
         // For more info on consuming ML.NET models, visit https://aka.ms/mlnet-consume
         // Method for consuming model in your app


### PR DESCRIPTION
(Otherwise its location will be relative to the "current directory," which could be anything, and is often incorrect.)