### PR TITLE
[build] remove `setup-java` step for MLTrainer build

### DIFF
--- a/.github/workflows/maui.yml
+++ b/.github/workflows/maui.yml
@@ -32,11 +32,6 @@ jobs:
       with:
         dotnet-version: 6.x
 
-    - uses: actions/setup-java@v2
-      with:
-        distribution: 'microsoft'
-        java-version: '11'
-
     - name: Install MAUI Workloads
       run: dotnet workload install maui --ignore-failed-sources
 


### PR DESCRIPTION
I think this would only be needed for Android apps. Since this app is Mac & Windows, we can skip it.