### PR TITLE
[actions] install just the `maui-desktop` workload

### DIFF
--- a/.github/workflows/maui.yml
+++ b/.github/workflows/maui.yml
@@ -36,7 +36,7 @@ jobs:
         dotnet-version: 6.x
 
     - name: Install MAUI Workloads
-      run: dotnet workload install maui --ignore-failed-sources
+      run: dotnet workload install maui-desktop --ignore-failed-sources
 
     - name: Build MAUI App
       run: dotnet publish Maui/MLTrainer/MLTrainer.sln -c Release


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/blob/release/6.0.4xx/src/Workload/Microsoft.NET.Sdk.Maui/WorkloadManifest.in.json#L19-L25

This way, we don't spend time installing Android/iOS packs.

1 min 36s -> 24s