### PR TITLE
Trim trailing punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,18 @@ const regex:RegExp = /`+[^`]+`+/gi;
 const replaced = text.replace(regex, '#code');
 ```
 
-TODO: standardize replacement of punctuation.
+Trailing punctuation should be replaced such as:
+
+```TypeScript
+const regex:RegExp = /(\.|!|\?|;|:)+$/g;
+const replaced = text.replace(regex, '');
+```
+
+Leading/trailing blank space should also be replaced:
+
+```TypeScript
+const final = text.trim();
+```
 
 ## `mlnet` .NET Global Tool
 

--- a/comments/classified.csv
+++ b/comments/classified.csv
@@ -1,42 +1,42 @@
 text,isnegative,importance
-ship it!,0,0.5
+ship it,0,0.5
 tests failed,0,0.5
-This sucks!,1,0.5
+This sucks,1,0.5
 "Ok, #code and #code might be a little better.",0,0.5
 "@github I figured this out friday, I think: https://github.com/xamarin/xamarin-android/pull/5597",0,0.5
 "Ignore above, it was a #code app.",0,0.5
 "When testing #code apps, Debug builds work",0,0.5
 You are so terrible,1,0.5
 This is terrible,1,0.5
-I have a feeling that NuGet authors will have to use #code for their directory names...,0,0.5
-You are a failure.,1,0.5
-There are test failures.,0,0.5
+I have a feeling that NuGet authors will have to use #code for their directory names,0,0.5
+You are a failure,1,0.5
+There are test failures,0,0.5
 The test failed with: compiler error on line 12,0,0.5
 "The one performance test that failed, I don't see anything related to this change",0,0.5
-Did this just get pasted twice?,0,0.5
-I believe I was only seeing the problem in an earlier incarnation of https://github.com/xamarin/monodroid/pull/1205.,0,0.5
+Did this just get pasted twice,0,0.5
+I believe I was only seeing the problem in an earlier incarnation of https://github.com/xamarin/monodroid/pull/1205,0,0.5
 "It seems both the startup & MSBuild perf tests fail to build, which is odd.",0,0.5
 I vehemently disagree with this,1,0.5
-Can we do something smarter than this?,1,0.5
-I don't like this solution.,1,0.5
-You can do this like this instead.,0,0.5
-Have you even tested this code before submitting?,1,0.5
+Can we do something smarter than this,1,0.5
+I don't like this solution,1,0.5
+You can do this like this instead,0,0.5
+Have you even tested this code before submitting,1,0.5
 🤮,1,0.5
 😠,1,0.5
 😡,1,0.5
-This is just sh*t.,1,0.5
-The conflict I get is due to stupid new gcc header file crap.,1,0.5
-But what makes me upset is that the crap is for completely bogus reasons.,1,0.5
+This is just sh*t,1,0.5
+The conflict I get is due to stupid new gcc header file crap,1,0.5
+But what makes me upset is that the crap is for completely bogus reasons,1,0.5
 "The above code is sh*t, and it generates shit code.",1,0.5
 "It looks bad, and there's no reason for it.",1,0.5
 "Give me *one* reason why it was written in that idiotic way with two different conditionals, and a shiny new nonstandard function that wants particular compiler support to generate even half-way sane code, and even then generates worse code?",1,0.5
-I love it!,0,0.5
+I love it,0,0.5
 So good,0,0.5
 Amazing,0,0.5
 Looks good to me,0,0.5
 LGTM,0,0.5
-Great Job!,0,0.5
-Does this work?,0,0.5
+Great Job,0,0.5
+Does this work,0,0.5
 It looks like a test failed,0,0.5
 This is not compiling,0,0.5
 Make sure that you compile before creating the pull request,0,0.5
@@ -59,7 +59,7 @@ Don't give up,0,0.5
 This is much better,0,0.5
 This is an improvement,0,0.5
 You are a saint,0,0.5
-Thank you!,0,0.5
+Thank you,0,0.5
 This is not exactly what we want,0,0.5
 This is a slightly better way to do this,0,0.5
 Removing this,0,0.5
@@ -67,18 +67,18 @@ You can close this for now,0,0.5
 Reopening this PR,0,0.5
 Please ignore this PR,0,0.5
 DO NOT MERGE,1,0.5
-Add the DO NOT MERGE label if it's not ready yet!,0,0.5
+Add the DO NOT MERGE label if it's not ready yet,0,0.5
 I hate this change,1,0.5
 Customers will hate this,1,0.5
 This CI sucks,1,0.5
 Change this now,1,0.5
 I will change this now - thank you for the feedback,0,0.5
 This is below your level,1,0.5
-Did a child write this?,1,0.5
-You can't make this any better?,1,0.5
+Did a child write this,1,0.5
+You can't make this any better,1,0.5
 This is not what we want,1,0.5
 Just let me do this,1,0.5
-You can't do anything right can you?,1,0.5
+You can't do anything right can you,1,0.5
 Everything is wrong,1,0.5
 Stop that,1,0.5
 Just quit,1,0.5
@@ -94,15 +94,15 @@ It's about the Invalid IL code,0,0.5
 There appears to be a stack misalignment,0,0.5
 The weak reference object will get cleared,0,0.5
 This code is garbage,1,0.5
-Did you account for garbage collection?,0,0.5
-Can't you do better?,1,0.5
+Did you account for garbage collection,0,0.5
+Can't you do better,1,0.5
 This is messy,1,0.5
-I learned something new!,0,0.5
+I learned something new,0,0.5
 I didn't know that,0,0.5
 This is great test coverage,0,0.5
 This is pretty gross,1,0.5
 There's nothing pretty about this,1,0.5
-This is very pretty code!,0,0.5
+This is very pretty code,0,0.5
 It isn't working,0,0.5
 This isn't worth my time,1,0.5
 It just doesn't make sense,1,0.5
@@ -149,12 +149,12 @@ my computer is frozen,0,0.5
 this is some grandfather code we'll be updating because it's so old and ugly,1,0.5
 this is some rollover code we'll be updating,0,0.5
 nice dummy values! but not nice enough,1,0.5
-nice sample values!,0,0.5
+nice sample values,0,0.5
 this is on my to-do list,0,0.5
 Don't do a half-ass job,1,0.5
-We always want to make things better.,0,0.5
-Maybe it's better to do this in another way?,0,0.5
-Do this in another way!,1,0.5
+We always want to make things better,0,0.5
+Maybe it's better to do this in another way,0,0.5
+Do this in another way,1,0.5
 Your code is completely wrong,1,0.5
 You're not the best developer here,1,0.5
 "After discussion with the team, we came to the conclusion that's better to do it this way.",0,0.5
@@ -162,13 +162,13 @@ You're not the best developer here,1,0.5
 Every line of code you write is a nail in my coffin,1,0.5
 This is rubbish,1,0.5
 This is toy code,1,0.5
-How long did you spend working on this?,1,0.5
-What are you doing?,1,0.5
+How long did you spend working on this,1,0.5
+What are you doing,1,0.5
 "You know this doesn't work like that, right?",1,0.5
-Can you explain what you are trying to accomplish?,0,0.5
-Can you explain how it works?,0,0.5
+Can you explain what you are trying to accomplish,0,0.5
+Can you explain how it works,0,0.5
 "I don't think this looks right, but I could be wrong. Could you explain what this is supposed to be doing?",0,0.5
-This is great!,0,0.5
+This is great,0,0.5
 I love this,0,0.5
 This is a great solution,0,0.5
 I would never have thought of doing it this way,0,0.5
@@ -201,170 +201,170 @@ Why don't you just skip this step,1,0.5
 "Ok, #code and #code might be a little better.",0,0.5
 "@github I figured this out friday, I think: https://github.com/xamarin/xamarin-android/pull/5597",0,0.5
 "Ignore above, it was a #code app. When testing #code apps, Debug builds work.",0,0.5
-But a #code build logs this and then crashes after:,0,0.5
-#code gives:,0,0.5
+But a #code build logs this and then crashes after,0,0.5
+#code gives,0,0.5
 Full log: [adb.txt](https://github.com/xamarin/xamarin-android/files/8643599/adb.txt),0,0.5
 "I have a feeling that NuGet authors will have to use #code for their directory names... where they have been used to using #code, #code, etc.",0,0.5
-The target that uses the #code item group doesn't run if you set #code:,0,0.5
+The target that uses the #code item group doesn't run if you set #code,0,0.5
 https://github.com/dotnet/sdk/blob/93b432bd8e73bb68aa4621db8a967d62e6f0cc23/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.GenerateImplicitNamespaceImports.targets#L35-L38,0,0.5
-Here is the commit that implements this:,0,0.5
+Here is the commit that implements this,0,0.5
 https://github.com/dotnet/sdk/commit/85943958e5a01d6bbd39a947aec2a4a37b8ba7cf,0,0.5
 "The one performance test that failed, I don't see anything related to this change:",0,0.5
 "#code or #code didn't run, so going to merge.",0,0.5
 /azp run,0,0.5
-Did this just get pasted twice?,0,0.5
+Did this just get pasted twice,0,0.5
 "As per the bug we were seeing with #code and #code, I think this needs to be:",0,0.5
 "After using #code + #code, I think it's still OK to just compare #code:",0,0.5
-It should be the first instance of #code and #code will be everything before it.,0,0.5
-The issue in https://github.com/xamarin/xamarin-android/pull/5991#issuecomment-854216388 should be working now.,0,0.5
-I believe I was only seeing the problem in an earlier incarnation of https://github.com/xamarin/monodroid/pull/1205.,0,0.5
+It should be the first instance of #code and #code will be everything before it,0,0.5
+The issue in https://github.com/xamarin/xamarin-android/pull/5991#issuecomment-854216388 should be working now,0,0.5
+I believe I was only seeing the problem in an earlier incarnation of https://github.com/xamarin/monodroid/pull/1205,0,0.5
 "I can't find anything sensible to do here, #code or #code throw during evaluation.",0,0.5
 "I think adding the test case is fine for now, and you would get the above error from #code?",0,0.5
 "@github there is something else weird here, but I think it's our test.",0,0.5
 "The cases where macOS failed, it seems like #code. So how would this class know to check if the files exist in that case?",0,0.5
 https://github.com/xamarin/xamarin-android/blob/968c4245d3bb24670f402eb207109ca837fdd195/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs#L634-L638,0,0.5
-Let's look into this again if it fails like this later...,0,0.5
+Let's look into this again if it fails like this later,0,0.5
 I was mainly trying to get the build log shorter 👀,0,0.5
 "It seems both the startup & MSBuild perf tests fail to build, which is odd.",0,0.5
-Are there some more of these? If I ignore tests:,0,0.5
+Are there some more of these? If I ignore tests,0,0.5
 "Since https://github.com/xamarin/xamarin-android/commit/e390702773365ffe3da975181d0aa398d42731d0 we dropped support for referencing exe's at the MSBuild level. I didn't add support for it here, but if there is some scenario you think we'll hit, I can add it.",0,0.5
-Offhand I can't think of a case where a #code would reference a random #code?,0,0.5
+Offhand I can't think of a case where a #code would reference a random #code,0,0.5
 /azp run,0,0.5
 "I tried to test these changes on an API 19 emulator, but ran into: https://github.com/xamarin/monodroid/issues/1161",0,0.5
 "You can have an #code with resources, then you might want to use #code values from C#.",0,0.5
 "So I don't think we need this by default, but it's there if you need to turn it off.",0,0.5
-An idea that could be done in a future iteration.,0,0.5
-Could this step also modify this class:,0,0.5
+An idea that could be done in a future iteration,0,0.5
+Could this step also modify this class,0,0.5
 https://github.com/xamarin/xamarin-android/blob/7ba62bac5a25eb783a6da9c2b6a989a820695a1f/src/Mono.Android/Android.Runtime/ResourceIdManager.cs#L6-L9,0,0.5
 "If #code was a completely empty method, some reflection could be skipped at startup.",0,0.5
-same here:,0,0.5
+same here,0,0.5
 Should we make this a #code just in case the version number changes? If this just removed an entire line that matches: #code,0,0.5
-I'll list #code.,0,0.5
-We are aspiring to change all these to:,0,0.5
+I'll list #code,0,0.5
+We are aspiring to change all these to,0,0.5
 /azp run,0,0.5
 "I think the code is the same, the first one would be the same as doing:",0,0.5
 "I've heard putting #code prevents a delegate object from being created, but that performance shouldn't be needed here.",0,0.5
-My plan was to not import or ship #code at all:,0,0.5
+My plan was to not import or ship #code at all,0,0.5
 https://github.com/xamarin/xamarin-android/blob/02e86b5a6bbd6f938c16cf30bc709543565bb34e/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L364-L365,0,0.5
-"However this is wrong ☝️ , it needs to be checking #code instead.",1,0.5
-This should also work:,0,0.5
+"However this is wrong ☝️, it needs to be checking #code instead.",1,0.5
+This should also work,0,0.5
 https://github.com/xamarin/xamarin-android/blob/91b66985704f1592b8c55819f7ff48d5e7353900/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L1160-L1161,0,0.5
 Fixed the ones in xamarin-android here: https://github.com/xamarin/xamarin-android/pull/5636,0,0.5
 /azp run,0,0.5
-NOTE: two #code and #code won't currently work -- there is a bug in AzDO.,0,0.5
-Since this could be a 4MB string:,0,0.5
+NOTE: two #code and #code won't currently work -- there is a bug in AzDO,0,0.5
+Since this could be a 4MB string,0,0.5
 https://github.com/xamarin/xamarin-android/blob/c98cb40f35a208c04466bb3fccb3cd25d463781c/build-tools/scripts/TestApks.targets#L94-L100,0,0.5
-Do you think it's worth making a #code method that would write each line to a file at a time? Instead of making a giant string?,0,0.5
+Do you think it's worth making a #code method that would write each line to a file at a time? Instead of making a giant string,0,0.5
 "The designer tests keep failing on NuGet restore, I think we can ignore:",0,0.5
-This looks OK:,0,0.5
+This looks OK,0,0.5
 * Designer macOS has been failing since last week on master,0,0.5
 * The one test failure is unrelated: #code,0,0.5
-Should we consider making this the default for all projects?,0,0.5
-We already do it for .NET 6:,0,0.5
+Should we consider making this the default for all projects,0,0.5
+We already do it for .NET 6,0,0.5
 https://github.com/xamarin/xamarin-android/blob/885b57bdcf32e559961b183e1537844c5aa8143e/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.props#L13,0,0.5
-Does this need to check some MSBuild property to skip it? Would it attempt to sign packages on Mac locally otherwise?,0,0.5
+Does this need to check some MSBuild property to skip it? Would it attempt to sign packages on Mac locally otherwise,0,0.5
 Could not AOT the assembly: System.Core.dll,0,0.5
 "This looks similar to some of the file locking issues we see on the bots, since it passes for me locally, let me do a retry.",0,0.5
 "So this will probably need to use TryGetValue now, somehow NUnit had a custom dictionary before that returned null when the key was not found?",0,0.5
 "Thanks to Pobst, it should go through here now: https://github.com/xamarin/xamarin-android/blob/1bee4ad176863bdfc0de258542a2c3685fc60f2d/src/Xamarin.Android.Build.Tasks/Tasks/AndroidTask.cs#L16-L21",0,0.5
 "I think using the default ""let it throw"" behavior is better now as long as this subclasses #code.",0,0.5
-The spec says the native platform files always win:,0,0.5
+The spec says the native platform files always win,0,0.5
 https://github.com/xamarin/xamarin-android/blob/main/Documentation/guides/OneDotNetSingleProject.md,0,0.5
 "If you want to use the MSBuild properties, you can just leave the values blank in #code or #code (or whatever the WinUI version is). You can still set MSBuild properties in #code files and override their values from CI.",0,0.5
-I updated the test case some -- it needs to set all the properties to weird values so we see who wins.,0,0.5
-I think this should be:,0,0.5
-So that users can override it in their #code file.,0,0.5
-Do we need this in every project? Can we put it in a new #code or #code?,0,0.5
-maybe this would be cleaner as:,0,0.5
+I updated the test case some -- it needs to set all the properties to weird values so we see who wins,0,0.5
+I think this should be,0,0.5
+So that users can override it in their #code file,0,0.5
+Do we need this in every project? Can we put it in a new #code or #code,0,0.5
+maybe this would be cleaner as,0,0.5
 "This is the only one I didn't address, I agree I would rather use #code, too.",0,0.5
-I just didn't think it was worth rewriting all this code--but if we were going to change the file drastically or something it might be worth it.,0,0.5
-#code should be imported here already.,0,0.5
-Could simplify this line:,0,0.5
+I just didn't think it was worth rewriting all this code--but if we were going to change the file drastically or something it might be worth it,0,0.5
+#code should be imported here already,0,0.5
+Could simplify this line,0,0.5
 /azp run,0,0.5
-The quoted stuff was all from:,0,0.5
-👍 I'll indent it.,0,0.5
-@github I bet this #code check was important...,0,0.5
-I need to look at what is in the typemaps in both cases.,0,0.5
+The quoted stuff was all from,0,0.5
+👍 I'll indent it,0,0.5
+@github I bet this #code check was important,0,0.5
+I need to look at what is in the typemaps in both cases,0,0.5
 "Right so we only should check if #code changes, and is newer than a stamp file or something.",0,0.5
-Something like (_untested_):,0,0.5
-This should make the second call skip #code if the assembly didn't change.,0,0.5
+Something like (_untested_),0,0.5
+This should make the second call skip #code if the assembly didn't change,0,0.5
 "When I build #code, I rarely change #code when working on MSBuild-related stuff. This should save ~3 seconds from my dev-loop.",0,0.5
 /azp run,0,0.5
 "Sounds good, we can leave #code for now.",0,0.5
-I don't think you need to set #code with #code.,0,0.5
+I don't think you need to set #code with #code,0,0.5
 "This imports #code, so I think it would get the value you want;",0,0.5
 https://github.com/xamarin/xamarin-android/blob/1877dd5ebee90452c6ab2cc33a58498a83ea7c1f/Configuration.props#L38,0,0.5
-Should we give an example in the commit message what the problem here was?,0,0.5
+Should we give an example in the commit message what the problem here was,0,0.5
 We somehow lost the #code NuGet in this file: https://github.com/xamarin/xamarin-android/commit/1d608bf194f5cddcb4d61a4bca3602f920da5246#diff-4469ed45319624df448a82ed4bc98b6d,0,0.5
 "I think we don't need it on this one, though. #code is called right before?",0,0.5
 "It would be nice if this had the full strack trace here, but we just have #code:",0,0.5
 https://github.com/xamarin/XamarinComponents/blob/4f5a57bd567f46f4b67622ab718b50485725463f/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/XamarinDownloadArchives.cs#L182,0,0.5
-Whoops I think this one should be the new #code.,0,0.5
+Whoops I think this one should be the new #code,0,0.5
 "Since this breaks things, I don't think it is important enough to continue.",0,0.5
-I'll leave the branch around if we ever want to try this again.,0,0.5
+I'll leave the branch around if we ever want to try this again,0,0.5
 /azp run,0,0.5
 "To test this currently, you would need: [MonoAOTCompiler.zip](https://github.com/xamarin/xamarin-android/files/6804264/MonoAOTCompiler.zip)",0,0.5
-Copy #code to #code. This will be needed until the changes land in dotnet/runtime and flow to us.,0,0.5
+Copy #code to #code. This will be needed until the changes land in dotnet/runtime and flow to us,0,0.5
 "If I remove it, I get:",0,0.5
 "We might want to just compare #code, if we want this to work the same as #code: https://github.com/mono/linker/blob/44199a2c62ff221f92c33cbb4ee3e35588adaf4a/tuner/Mono.Tuner/CustomizeActions.cs#L47",0,0.5
 "This would give the option to add this to the support libraries, and not have to build with a new (not yet released) Xamarin.Android.",0,0.5
 "I added #code, which seems a lot better.",0,0.5
-Does this need all 4 steps here? or can it just call #code?,0,0.5
-Do you really need all three of these? Are we missing a dependency where you should be able to put #code and that's it?,0,0.5
+Does this need all 4 steps here? or can it just call #code,0,0.5
+Do you really need all three of these? Are we missing a dependency where you should be able to put #code and that's it,0,0.5
 "Ok, the build is broken because the #code file isn't being created by this project now.",0,0.5
 "I think you need to import #code otherwise, this target won't run because #code is blank:",0,0.5
 https://github.com/xamarin/xamarin-android/blob/d17ea01b4036c2592ae247b24af14739d949f245/build-tools/create-pkg/create-pkg.targets#L148-L150,0,0.5
-I think I should just remove all the #code here and put #code instead.,0,0.5
+I think I should just remove all the #code here and put #code instead,0,0.5
 "I saw this message ~2700 times in a build log. It is still logging the *other* case, which I think is sufficient.",0,0.5
 I updated the commit message around this conversation 👍,0,0.5
 /azp run,0,0.5
-Right now I don't think you can use LLVM without having an NDK -- but I was thinking we could fix that? Like it should be possible to work?,0,0.5
+Right now I don't think you can use LLVM without having an NDK -- but I was thinking we could fix that? Like it should be possible to work,0,0.5
 "If you didn't need the NDK, we could enable LLVM by default for #code builds to improve startup times.",0,0.5
-It might be this was just something broken on mono/master:,0,0.5
-It looks like they moved the submodule? So maybe it's in #code now?,0,0.5
+It might be this was just something broken on mono/master,0,0.5
+It looks like they moved the submodule? So maybe it's in #code now,0,0.5
 https://github.com/mono/mono/tree/a2f9fb77a3704049ffe5de32362029ece154ee4c/external,0,0.5
 "I am building a mono archive based off 2019-10, will give that a try.",0,0.5
-We don't have darc in this repo at all yet. Putting the version number in #code follows our current pattern until that is in place.,0,0.5
+We don't have darc in this repo at all yet. Putting the version number in #code follows our current pattern until that is in place,0,0.5
 "@github will be looking into darc, I think. We can start with getting it to bump the dotnet/sdk version.",0,0.5
-I think all these #code should just use #code instead:,0,0.5
+I think all these #code should just use #code instead,0,0.5
 "Both will probably work in this case, but I've seen some weird things if you run the #code target first followed with #code.",0,0.5
 "When I last attempted to split up #code, it hurt performance a bit, I had to move the #code to be stored in #code so it could be shared across multiple tasks:",0,0.5
 https://github.com/xamarin/xamarin-android/compare/master...jonathanpeppers:split-generatejavastubs,0,0.5
 "This branch isn't quite finished, the #code portion is broken.",0,0.5
 I think we do need the #code setting: https://git-scm.com/docs/gitattributes#Documentation/gitattributes.txt-Settostringvaluecrlf,0,0.5
-To test this I did:,0,0.5
-And then it switches to Windows line endings when I look in notepad++:,0,0.5
+To test this I did,0,0.5
+And then it switches to Windows line endings when I look in notepad++,0,0.5
 "Using just #code, and trying again--it didn't work.",0,0.5
-But the docs aren't exactly clear if someone else knows better?,0,0.5
+But the docs aren't exactly clear if someone else knows better,0,0.5
 "This one could also use #code, sorry I didn't see it before.",0,0.5
-👍 I guess we weren't doing that at all before???,0,0.5
+👍 I guess we weren't doing that at all before,0,0.5
 "Instead of reading the file back into memory, could we make a helper method that logs and writes for each call?",0,0.5
-Something like:,0,0.5
+Something like,0,0.5
 "The build failures look to be on master, too: apk sizes, tls tests, designer, libZipSharp/DotNetPackageXASdkProject test.",0,0.5
 "I reworked the task, so it only writes the file when needed.",0,0.5
-attempting to extract @(EmbeddedResource)s when an assembly doesn't have any.,0,0.5
-Maybe I need to see if this can work without any assembly-level attributes at all.,0,0.5
+attempting to extract @(EmbeddedResource)s when an assembly doesn't have any,0,0.5
+Maybe I need to see if this can work without any assembly-level attributes at all,0,0.5
 #code,0,0.5
 "@github in https://github.com/xamarin/xamarin-android/pull/6539 I remember some LLVM tests failed when I tried, but there are other changes in xamarin-android/main now. Could the LLVM-IR support @github added make this work now?",0,0.5
 "If you're testing, and LLVM is working without an NDK let's try it.",0,0.5
 /azp run,0,0.5
 "Does this need to check #code and use either: #code, #code, or #code?",0,0.5
-Is there a way this could check for #code then use 32? Trying to think of what this would look like over time as more API levels are added.,0,0.5
+Is there a way this could check for #code then use 32? Trying to think of what this would look like over time as more API levels are added,0,0.5
 "I think this might need to check if it is blank, like it does in .NET 6:",0,0.5
 https://github.com/xamarin/xamarin-android/blob/d4da1c252f45c4910abc1bd9e5be9ecf9dc683a0/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets#L13,0,0.5
-This way you can set it to #code.,0,0.5
+This way you can set it to #code,0,0.5
 I agree with the concern here: https://github.com/xamarin/xamarin-android/pull/6541#issuecomment-985045429,0,0.5
 "If this is #code, how do you implement ""ssl pinning"" in an app?",0,0.5
 "👍  I haven't seen this syntax yet, seems better than this:",0,0.5
-@github do you want to try setting #code to a folder in #code?,0,0.5
+@github do you want to try setting #code to a folder in #code,0,0.5
 https://github.com/xamarin/XamarinComponents/blob/4f5a57bd567f46f4b67622ab718b50485725463f/Util/Xamarin.Build.Download/source/Xamarin.Build.Download/Xamarin.Build.Download.targets#L9,0,0.5
 "Then when it retries, I think it could start with a fresh empty directory.",0,0.5
-Should this entire file go in this #code?,0,0.5
+Should this entire file go in this #code,0,0.5
 https://github.com/xamarin/xamarin-android/blob/master/Documentation/guides/DotNet5.md,0,0.5
-Then maybe we don't even need a #code here?,0,0.5
-Maybe we should use #code instead? Would all #code tests fail without crypto?,0,0.5
-I'm feeling as the number of MSBuild files start to grow...,0,0.5
-@github do you think we should start putting a short comment/description at the top of each new MSBuild file to explain what the file is?,0,0.5
+Then maybe we don't even need a #code here,0,0.5
+Maybe we should use #code instead? Would all #code tests fail without crypto,0,0.5
+I'm feeling as the number of MSBuild files start to grow,0,0.5
+@github do you think we should start putting a short comment/description at the top of each new MSBuild file to explain what the file is,0,0.5
 "So we would want just a short sentence explaining the difference between #code and #code? #code, too?",0,0.5
 "If I made a #code the name is almost self-explanatory, but would probably be helpful to say ""this is where all #code properties go"".",0,0.5
 @github it looks like @github looked at these codes? https://github.com/xamarin/xamarin-android/pull/2258,0,0.5
@@ -373,54 +373,54 @@ I'm feeling as the number of MSBuild files start to grow...,0,0.5
 https://github.com/xamarin/xamarin-android-tools/blob/2d3690e428c8523b3779f84e5c804d1fd3c0d6fe/src/Xamarin.Android.Tools.AndroidSdk/AndroidVersions.cs#L139-L176,0,0.5
 "So the question is, do we ship all the #code or update this list?",0,0.5
 "I see a new version #code, waiting to see if that is what we should bump to.",0,0.5
-I'm curious can remove #code here and it uses the name of the #code file?,0,0.5
+I'm curious can remove #code here and it uses the name of the #code file,0,0.5
 "From the #code files we have, it looked like this file was renamed:",0,0.5
 "I think NuGet always puts #code for all of #code, #code, #code.",0,0.5
 "It looks like this project links in a few files from #code, can you add a new file here:",0,0.5
 https://github.com/xamarin/xamarin-android/blob/af7f7f5da475c5cb8d2d725d77082ba7915bbc7e/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj#L43-L46,0,0.5
 "We probably should make this a regular project reference, but you don't have to do that here -- we can do it later.",0,0.5
-Should I create an issue and link that in the binding?,0,0.5
-Thanks!,0,0.5
-Will merge after issues with main are resolved!,0,0.5
-@github  @github Would these need this variable too when we move out of .NET6?,0,0.5
-Again in that file here:,0,0.5
+Should I create an issue and link that in the binding,0,0.5
+Thanks,0,0.5
+Will merge after issues with main are resolved,0,0.5
+@github  @github Would these need this variable too when we move out of .NET6,0,0.5
+Again in that file here,0,0.5
 "@github  Ah good catch! I didn't realize I was calling the same method... The reason I made this change is that the SetHighlightedItemForProperty (int property, int identifier) is Obsolete and suggests that I use this one - which in this case does not make sense. Should I in fact continue to use the obsoleted one?",0,0.5
 Updating to fix unrelated failure: https://github.com/xamarin/maccore/issues/2472,0,0.5
 "Thanks for catching these, I followed Sebastian's advice about removing the [Introduced] attribute and removing the messages that don't give us much info in the Enums.cs file but not this one. If the documentation does not give a good method to use instead, would I just clear the entire message for these as well? In this case, there are other functions that can fetch assets using different types of parameters. Should I say something along the lines of ""Use other fetchasset methods""?",0,0.5
 "I thought these were better to give us more detailed exceptions, but the compiler does not recognize these #codes as ending the method so I kept the old one at the end of the method...",0,0.5
-Merging since the test failures are unrelated timeouts!,0,0.5
+Merging since the test failures are unrelated timeouts,0,0.5
 @github @github AH okay thank you both for the explanations! I will get right on this :),0,0.5
 "I can create a LPLinkView with the size 5,5 at dimensions 5,5",0,0.5
-I noticed the OneLocBuild task has failing due to the PAT in a different branch while testing this.,0,0.5
-Connor was able to fix it!,0,0.5
-Turning this into a draft since we will need more discussion on this before moving forward!,0,0.5
+I noticed the OneLocBuild task has failing due to the PAT in a different branch while testing this,0,0.5
+Connor was able to fix it,0,0.5
+Turning this into a draft since we will need more discussion on this before moving forward,0,0.5
 "Update: still testing on my end, for some reason @github 's solution isn't working on my end.. Sounds like it is working for others though.",0,0.5
-Working on a test for this now!,0,0.5
+Working on a test for this now,0,0.5
 "While I realize that I added a good amount of these and that SetData () throws an exception if the value arg is null, I thought it would be better to explicitly add the exceptions here and not use a #code, but I am open to opinions!",0,0.5
 "I will make a comment of this too, but the reasoning is a little confusing to me. I remember I could not build the file and @github may remember, but there is a file src/Photos/PHAssetChangeRequest.cs that has an Obsolete attribute in the PHAssetChangeRequest empty constructor and we deemed that is what was causing the build issue. However, now I am confused because this class is PHChangeRequest and not PHAssetChangeRequest. I can talk to Alex about this tomorrow and get back to you with more clarification.",0,0.5
-Does this look okay?,0,0.5
-@github @github  does #code meet all these criteria? Also could this change be in a separate PR?,0,0.5
-@github So I just tried to apply the mac attributes to this one and a few of them below that say they are available for mac as well and they were getting a lot of compile errors.,0,0.5
+Does this look okay,0,0.5
+@github @github  does #code meet all these criteria? Also could this change be in a separate PR,0,0.5
+@github So I just tried to apply the mac attributes to this one and a few of them below that say they are available for mac as well and they were getting a lot of compile errors,0,0.5
 It turns out that these are the questionable interfaces in this src/quicklook.cs,0,0.5
-It turns out that they are also in src/quicklookui.cs and are all decorated with mac attributes already.,0,0.5
-Do you think this could be leading to the issue?,0,0.5
+It turns out that they are also in src/quicklookui.cs and are all decorated with mac attributes already,0,0.5
+Do you think this could be leading to the issue,0,0.5
 [Here is the gist](https://gist.github.com/tj-devel709/03492abdf722192da23b84ae921f7e05) with the errors that marking mac for each of these interfaces show,0,0.5
-I'll just leave the action in!,0,0.5
+I'll just leave the action in,0,0.5
 "@github There was no MacCatalyst.todo, but most of these interfaces say they support MacCatalyst in the web docs.",0,0.5
-I tried including the HomeKit in the MacCatalyst section of the frameworks.source file and I kept getting this error in the build:,0,0.5
-Is this something I should do?,0,0.5
+I tried including the HomeKit in the MacCatalyst section of the frameworks.source file and I kept getting this error in the build,0,0.5
+Is this something I should do,0,0.5
 "Are enums int by default? If so, is there a reason to declare int?",0,0.5
-Right now it is set as a property though and properties don't need a verb correct? I can revert to a method though.,0,0.5
+Right now it is set as a property though and properties don't need a verb correct? I can revert to a method though,0,0.5
 "Okay, applied!",0,0.5
 Maybe,0,0.5
 "nit, small extra space",1,0.5
 How about #code,0,0.5
-dont link/Mac Catalyst [dotnet]/Release [dotnet]: TimedOut (Execution timed out after 1200 seconds.,0,0.5
+dont link/Mac Catalyst [dotnet]/Release [dotnet]: TimedOut (Execution timed out after 1200 seconds,0,0.5
 No test log file was produced),0,0.5
 link sdk/tvOS - simulator/Debug: Failed,0,0.5
 link sdk/tvOS - simulator/Release: Failed,0,0.5
 **Unrelated Test Failure**,0,0.5
-Good catch! Removing now!,0,0.5
+Good catch! Removing now,0,0.5
 small also,0,0.5
 nit: missing new line,0,0.5
 "So I'm not sure if this is sufficient but I included Mac in an iOS Xcode project (which I think is how you enable Mac Catalyst), included HomeKit, and then called some things that are supported in Mac Catalyst (14,0) according to the web docs and Xcode does not complain about it!",0,0.5
@@ -428,29 +428,29 @@ lol,0,0.5
 Looks like extra indentation here,0,0.5
 "Oops sorry, actually forgot it haha",0,0.5
 Thanks for explaining! :),0,0.5
-@github that is a great question... Yeah this is the generated method signature:,0,0.5
+@github that is a great question... Yeah this is the generated method signature,0,0.5
 And CategoryToToken says it returns an #code,0,0.5
-Although there are no compiler warnings/errors regarding this..,0,0.5
-Should we be replacing this #code with an #code?,0,0.5
-@github maybe just an if statement inside that makes those changes ~ adds watch to the legacy and doesn't go though the platforms for the dotnet_iOS_MacCatalyst?,0,0.5
+Although there are no compiler warnings/errors regarding this,0,0.5
+Should we be replacing this #code with an #code,0,0.5
+@github maybe just an if statement inside that makes those changes ~ adds watch to the legacy and doesn't go though the platforms for the dotnet_iOS_MacCatalyst,0,0.5
 Unrelated failing test: https://github.com/xamarin/maccore/issues/2434,0,0.5
 "So I actually don't who told me to add the Sealed, perhaps @github ?",0,0.5
 "But when I remove it, I get these build errors: https://gist.github.com/tj-devel709/d459d9e717a186486deab6479f57c050",0,0.5
 Sebastien recommended that we change the ArgumentNullException's as well in these Nullability PRs,0,0.5
 It's the first time I remember seeing #code cool haha,0,0.5
 Same here,0,0.5
-What does this line do?,0,0.5
-There a few others as well!,0,0.5
+What does this line do,0,0.5
+There a few others as well,0,0.5
 * accidentally pulled xamarin/main. Trying to revert merge. Added do-not-merge for now,0,0.5
 "Oops forgot to run tests, I'll do that now",0,0.5
-Maybe typo?,0,0.5
+Maybe typo,0,0.5
 nit: extra new line,0,0.5
-Oh okay yeah sure that makes sense!,0,0.5
-Looks like Sebastien's test fails when these are removed so maybe they are needed:,0,0.5
-perhaps 'duplicated'?,0,0.5
-Thanks!,0,0.5
+Oh okay yeah sure that makes sense,0,0.5
+Looks like Sebastien's test fails when these are removed so maybe they are needed,0,0.5
+perhaps 'duplicated',0,0.5
+Thanks,0,0.5
 Enum value looks strange,0,0.5
-You can add the iOS availability on enums and their individual values too.,0,0.5
+You can add the iOS availability on enums and their individual values too,0,0.5
 "Automatic,",0,0.5
 "AutomaticOutLine,",0,0.5
 "Also just a small thing but add a comma after the AutomaticOutLine so that if anyone else ever adds something to your enum, their name won't show up in the blame and seem like they added that value. Great job! :)",0,0.5
@@ -460,7 +460,7 @@ Closing this PR in favor of: https://github.com/xamarin/xamarin-macios/pull/1439
 "OK, let's YOLO this 😁",0,0.5
 Sounds good 😂,0,0.5
 @github changes look good. Interestingly all the ignored enums and functions are in all platforms supported by the framework. There is an option to create a single ignore file that uses common-* as the prefix rather than the platform name. Food for though 😉,0,0.5
-@github  Would you recommend that I change it to common? Would it still be okay in common if it doesn't cover watchOS also?,0,0.5
+@github  Would you recommend that I change it to common? Would it still be okay in common if it doesn't cover watchOS also,0,0.5
 Flagging just in case since lowest supported is 10.14,0,0.5
 Flagging this just in case - not supported iOS version in .NET,0,0.5
 **Unrelated test failure**,0,0.5
@@ -469,37 +469,37 @@ monotouch-test/tvOS - simulator/Debug: Failed,0,0.5
 Updating to fix this unrelated issue: https://github.com/xamarin/maccore/issues/2472,0,0.5
 **Unrelated Test Failures**,0,0.5
 These paths are incorrect - WIP,0,0.5
-Will do!,0,0.5
+Will do,0,0.5
 "This is cool, I didn't know we could do this",0,0.5
-Merging since the test failures are unrelated timeouts!,0,0.5
+Merging since the test failures are unrelated timeouts,0,0.5
 "Oh gosh, I really messed that up ☝️",0,0.5
 "Alex helped suggest that name since the comment on xcode is ""/// The handle for the person that will be displayed on the incoming call notification.""",0,0.5
-@github hmmm what does the semicolon in this path name do?,0,0.5
-Perhaps this will give me a clue on how the apidiff directory is being set?,0,0.5
+@github hmmm what does the semicolon in this path name do,0,0.5
+Perhaps this will give me a clue on how the apidiff directory is being set,0,0.5
 "@github let me know if the json was tool generated, in that case ignore my comments.",0,0.5
 Yes they were auto generated. The output used spaces instead of tabs though so it is possible that I messed up indentation when trying to use tabs to not show changes in Rolf's existing json,0,0.5
 "Awesome, thanks @github !!",0,0.5
-Do we want to remove these maccatalyst's?,0,0.5
+Do we want to remove these maccatalyst's,0,0.5
 "Sorry, my mistake, both test failures are unrelated:",0,0.5
 "Also if I try (IList<string>) as a cast, I get this:",0,0.5
-System.InvalidCastException : Specified cast is not valid.,0,0.5
+System.InvalidCastException : Specified cast is not valid,0,0.5
 small formatting,0,0.5
 "Sorry, I don't think this one is actually ready for review. I think there are some things in the headers that were not mentioned by xtro that need updating!",0,0.5
 small typo,0,0.5
-That is a good point.,0,0.5
+That is a good point,0,0.5
 BTW these are the two bugs that we will try to patch for .NET 6.x that are preventing JS initializers from working in .NET MAUI,0,0.5
 "In theory, the ""best"" way to make this work is to use Blazor JS module initializers, but unfortunately there is currently a bug that prevents them from working as intended.",0,0.5
-This was an access violation.,0,0.5
+This was an access violation,0,0.5
 Please remember to address the cancelled task,0,0.5
 There was a fail fast exception,0,0.5
 I missed updating this test,0,0.5
-This avoids poor performance of GetHashCode and Equals that are used for the struct using reflection on the first field.,0,0.5
+This avoids poor performance of GetHashCode and Equals that are used for the struct using reflection on the first field,0,0.5
 "Also, contrary to the other default includes, add a condition so files are only included if we have a resource prefix (typically ""Resources""), otherwise the entire hard drive might be included",0,0.5
-I am seeing unmanaged crashes but I think our fix was just in Preview 13.,0,0.5
+I am seeing unmanaged crashes but I think our fix was just in Preview 13,0,0.5
 "Maybe I should be more verbose, but the comment before was listing 2 brief comments.",0,0.5
-The ListView is displaying incorrectly.,0,0.5
-In order for the the Button to display correctly.,0,0.5
-The point of the ExecutionMode platform specific was to tell WebView on UWP to run out of process.,0,0.5
+The ListView is displaying incorrectly,0,0.5
+In order for the the Button to display correctly,0,0.5
+The point of the ExecutionMode platform specific was to tell WebView on UWP to run out of process,0,0.5
 "Just invoking the Current property causes a crash, so you must be working some magic!",0,0.5
 "I was able to replicate the failures locally, and the most likely reason for the failures is the loss of focus by the test form",0,0.5
 "How, if at all, does this relate to AutomationProperties?",0,0.5
@@ -507,42 +507,42 @@ The point of the ExecutionMode platform specific was to tell WebView on UWP to r
 trying again now,0,0.5
 "updated, thanks for the feedback!",0,0.5
 @github told me blazor already has this type of theming via bootstrap styles,0,0.5
-should this also be MauiComboBox?,0,0.5
+should this also be MauiComboBox,0,0.5
 Thanks for the feedback @github! Opened an issue here https://github.com/dotnet/maui/issues/4766 - feel free to add more info,0,0.5
-What is the expected updated behavior here?,0,0.5
-will do!,0,0.5
+What is the expected updated behavior here,0,0.5
+will do,0,0.5
 missing d,0,0.5
 "I was told that it's best to use Brushes for Background colors and Colors everywhere else (cc @github) and yep, I added a bunch of colors/brushes that don't get used - exact colors are still a bit tentative, but I'll see what @github thinks for that",0,0.5
 failing tests unrelated,0,0.5
 The built-in platforms also use color for interactive controls,0,0.5
 nitpick typo fix that's been bothering me,1,0.5
-fixing now - but can you remind me why the null check is sufficient for Android and not iOS?,0,0.5
+fixing now - but can you remind me why the null check is sufficient for Android and not iOS,0,0.5
 "Hi, @github - what's ths issue you're seeing on iOS? Is it also the same error regarding #code ?",0,0.5
 NRE is thrown now at https://github.com/dotnet/maui/blob/a6a535c59cca18c65cdc9e2aaf554c4eddfaa81a/src/Core/src/Hosting/AppHostBuilderExtensions.cs#L119 Placeholder looks great otherwise,0,0.5
 I put this sample code directly in my local version of the control gallery sample: It uses #code like the samples in the referenced issues do,0,0.5
 See following comment first (I'm assuming this naming is related to #code which doesn't fully make sense to me),0,0.5
 "fixed, thank you! 😂",0,0.5
 still not working :(,0,0.5
-Should we add more tests for the other shapes? Or is Ellipse sufficient?,0,0.5
+Should we add more tests for the other shapes? Or is Ellipse sufficient,0,0.5
 TextColor is here to prevent issues wrt not implementing the full interface properly,0,0.5
 We should also link to instructions on how people can obtain the logs so they can also just attach them here,0,0.5
 "oops, yeah. removing the redundancy; thanks for the catch!",0,0.5
 "@github there's a number of confusing NREs thrown on this branch that are unresolved. If you could take a look and share any tips you might have, that would be awesome!",0,0.5
 "Why is it called ""QueryEditor"" and ""_editor""? Shouldn't it be ""entry""?",0,0.5
-What's happening here? Why is it no longer async and what does the func() do that's different?,0,0.5
+What's happening here? Why is it no longer async and what does the func() do that's different,0,0.5
 "I wonder how we can make this a bit more flexible, so that we get not just the platform but the specific API versions!",0,0.5
-What is MaxLength=-1 expected to do?,0,0.5
+What is MaxLength=-1 expected to do,0,0.5
 and wherever it's used/referenced,0,0.5
 "@github I fixed the ugly rebase! Build is failing now because Shadow is using Color and Size though, so that still needs to be fixed",1,0.5
 Can we use the same vars for consistency?`,0,0.5
 "Ok, thanks! Changed it back. I hadn't been sure because I know both brushes and colors can be used for Background, and assumed it might be the same with Backgroundcolor",0,0.5
-will do!,0,0.5
+will do,0,0.5
 @github will try again... did you change the background color though? I wonder if that's related,0,0.5
-can do!,0,0.5
+can do,0,0.5
 "should we consider changing the default too? So that if a developer doesn't explicitly set a description, it'll still make sense?",0,0.5
-Maybe we can do something similar to image where it simply can't receive focus at all and won't read out anything - maybe we can make it so just the contents are accessible?,0,0.5
+Maybe we can do something similar to image where it simply can't receive focus at all and won't read out anything - maybe we can make it so just the contents are accessible,0,0.5
 "Or alternatively, we can try to make the textual contents or at least the first textual content get propagated upward",0,0.5
-nice!,0,0.5
+nice,0,0.5
 "We woud need to check what the screen reader behavior is - does the TalkBack focus move with the keyboard focus? If it's inconsistent, we need to figure out what the desired behavior is there. If it's consistent, then I think this is an OK solution",0,0.5
 I agree! I just wanted to leave them for @github in case there are any we want to comment in before I delete them entirely,0,0.5
 Commented out because the values aren't clear yet and we want your opinions on what the values should be :),0,0.5
@@ -551,22 +551,22 @@ Commented out because the values aren't clear yet and we want your opinions on w
 "ah ok, makes sense! docs for #code was a big confusing and seemed right to me at first, since I was thinking the container should usually not receive any focus. But your explanation of ""consider first as a viable focus target"" helps clarify things",0,0.5
 /azp run,0,0.5
 typo fix that's been bothering me,1,0.5
-done!,0,0.5
+done,0,0.5
 "sorry, I misread which APIs were being used - taking back what I said and seconding Shane here!",0,0.5
 gotcha - will fix both here and in XCT soon,0,0.5
 @github I tried that but it didn't work for me :/ will try again though,0,0.5
-Is the body correct? Is it related to CursorPosition and not SelectionLength?,0,0.5
-Where did this 50 come from?,0,0.5
-Should we maybe set this to ImportantForAccessibility.Auto instead of null?,0,0.5
+Is the body correct? Is it related to CursorPosition and not SelectionLength,0,0.5
+Where did this 50 come from,0,0.5
+Should we maybe set this to ImportantForAccessibility.Auto instead of null,0,0.5
 "yep! We're trying to get the SearchView, and it looks like that TextView is being uesd as the SearchView. The SearchButton stuff we were using before was wrong / not quite relevant",0,0.5
 "alpha version was incorporated, and code significantly simplified. security nuget still needs to be added to nuget feed, so waiting on that! in the meantime, if any folks are able to test on android api levels 21/22, that would be super helpful - thanks!",0,0.5
 missing d,0,0.5
-@github font scaling will automatically be enabled across all the platforms including iOS now!,0,0.5
-Should we not set a background color on any pages then and just let the system handle that?,0,0.5
+@github font scaling will automatically be enabled across all the platforms including iOS now,0,0.5
+Should we not set a background color on any pages then and just let the system handle that,0,0.5
 "My thinking was that the background should be light in light mode, dark in dark mode, and since #code property is derived from VisualElement, which Page is based on, this is how I handled it. Most of the specific pages themselves (i.e. ContentPage) don't have stylable properties if not for those derived from Page and VisualElement",0,0.5
-maybe we can at least have the mainpage code in comments?,0,0.5
+maybe we can at least have the mainpage code in comments,0,0.5
 "hmm I tested again, but it's the same :/",0,0.5
-Could you share an example so that I can understand this better? I'm wondering why it's [#code](https://developer.android.com/reference/android/view/ViewGroup#FOCUS_BEFORE_DESCENDANTS) instead of [#code](https://developer.android.com/reference/android/view/ViewGroup#FOCUS_AFTER_DESCENDANTS). Is the #code here the rootView or the contained views?,0,0.5
+Could you share an example so that I can understand this better? I'm wondering why it's [#code](https://developer.android.com/reference/android/view/ViewGroup#FOCUS_BEFORE_DESCENDANTS) instead of [#code](https://developer.android.com/reference/android/view/ViewGroup#FOCUS_AFTER_DESCENDANTS). Is the #code here the rootView or the contained views,0,0.5
 @github yes definitely! so this PR does both of those things! It both: 1. Ensures font scaling will automatically be enabled across all the platforms including iOS 2. Introduces a #code boolean property that can be set to #code if so desired,0,0.5
 still seeing similar issues where hovering changes the color,0,0.5
 "@github I agree that with this calculator sample specifically, gray might work better with the general color scheme. Unfortunately, the proposed colors aren't accessible so I think it would be best to keep the current colors which have already been tested and validated for accessibility via our templates. Naturally, different colors might look better with different samples and scenarios, and folks can always change these styles as they wish. If you want to use grays for the calculator sample, I recommend a light gray button on black background in dark mode! But again, for the templates, I think keeping the current button style (with regard to colors) is ideal in terms of accessibility.",0,0.5
@@ -574,8 +574,8 @@ Windows SearchBar MaxLength will need some more time https://github.com/dotnet/m
 AFAICT failing tests are unrelated,0,0.5
 @github this is what @github was asking you for me about! wondering what a better way of doing this might be,0,0.5
 same feedback applies to all the templates,0,0.5
-why is this commented out? Should it be deleted?,0,0.5
-Is TextColor not yet expected to work?,0,0.5
+why is this commented out? Should it be deleted,0,0.5
+Is TextColor not yet expected to work,0,0.5
 "yes, so shouldn't we be checking here that it's YES instead of AUTO?",0,0.5
 same issue as #741 again NRE is thrown now at https://github.com/dotnet/maui/blob/a6a535c59cca18c65cdc9e2aaf554c4eddfaa81a/src/Core/src/Hosting/AppHostBuilderExtensions.cs#L119,0,0.5
 "Oo makes sense, thanks!!",0,0.5
@@ -585,25 +585,25 @@ Sample and device tests still need to be tested on iOS,0,0.5
 "nice var name 😂  ""whatDoIDo""",0,0.5
 similar feedback applies to all dropdowns,0,0.5
 "There are some new test failures, this is terrible.",1,0.5
-This is the worst thing that has ever happened.,1,0.5
+This is the worst thing that has ever happened,1,0.5
 This is such a bad way to do things,1,0.5
 This is crazy good,0,0.5
 "i think we should keep the hostingContext, we might in the future add stuff to the hostingcontext, and you can use it to decide what to register.",0,0.5
-won't we neeed this mirror on internal feeds? @github  ?,0,0.5
-@github  i think we can remove this change right?,0,0.5
+won't we neeed this mirror on internal feeds? @github,0,0.5
+@github  i think we can remove this change right,0,0.5
 @github  nop i don't think so it's not on version details,0,0.5
 now we will need to update the oder ITextinput implementations,0,0.5
 i m with @github  on this one,0,0.5
 Needs rebase,0,0.5
-Can you make a PR with that?,0,0.5
+Can you make a PR with that,0,0.5
 I will merge this now just to fix running android,0,0.5
 "this cast was failing, and that's why clearing selection wasn't working. We need to find a better way to fix this cast, for example implement a Interface on the SelectableItemsViewAdapter",0,0.5
 grrr @github,0,0.5
 "<img width=""1505"" alt=""image"" src=""https://user-images.githubusercontent.com/1235097/164044472-18c6290a-d687-4f16-952d-849581b764ca.png"">",0,0.5
 https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6043261&view=results,0,0.5
-can we move this to a helper method? and add some comments ?,0,0.5
-This should be the same issue we discussed before with @github  where adding the same view without removing it will hide the issue.,0,0.5
-Can you also add a test for this please?,0,0.5
+can we move this to a helper method? and add some comments,0,0.5
+This should be the same issue we discussed before with @github  where adding the same view without removing it will hide the issue,0,0.5
+Can you also add a test for this please,0,0.5
 no luck :(,1,0.5
 waiting for the next bump that is building,0,0.5
 Fine for me,0,0.5
@@ -612,119 +612,119 @@ We have #7107,0,0.5
 uwp missing,0,0.5
 "Can we add a device test, and check if with clip the  ImageButton has color on the first top left pixel ?",0,0.5
 If we want this on sr2 it should be target net6.0 branch,0,0.5
-"Hey, @github  we were marking continue on error on the xaml unit tests , we have 2 sln one for net6 other for classic. Build Windows is the classic one, we then have Pack/Build net6 in Windows/macOS",0,0.5
-Is it possible do add a windows device test for this ?,0,0.5
+"Hey, @github  we were marking continue on error on the xaml unit tests, we have 2 sln one for net6 other for classic. Build Windows is the classic one, we then have Pack/Build net6 in Windows/macOS",0,0.5
+Is it possible do add a windows device test for this,0,0.5
 "Maybe i don't understand, is this pixel density ?",0,0.5
-Do we want to rename also #code  #code?,0,0.5
-is there a way we could test this ?,0,0.5
+Do we want to rename also #code  #code,0,0.5
+is there a way we could test this,0,0.5
 "An error occurred while loading the YAML build pipeline. Unexpected symbol: 'or'. Located at position 54 within expression: eq(variables['Build.SourceBranch'], 'refs/heads/loc' or startsWith(variables['Build.SourceBranch'], 'refs/heads/loc-'). For more help, refer to https://go.microsoft.com/fwlink/?linkid=842996",0,0.5
-Should this be under Hosting/Fonts ?,0,0.5
-should this be #if DEBUG ?,0,0.5
+Should this be under Hosting/Fonts,0,0.5
+should this be #if DEBUG,0,0.5
 "This will throw at runtime, but we need to start giving translation to these message.",0,0.5
 does it need rebase? this change was in already,0,0.5
-Do we need the Default ?,0,0.5
+Do we need the Default,0,0.5
 if i $(MicrosoftExtensionsFileProvidersEmbeddedPackageVersion) for non net6 isn't also the order important? i m not a expert of msbuild so not sure tbh,0,0.5
-@github  if you check UWP on Xamarin Forms the title is above..,0,0.5
-. image](ht.,0,0.5
-Do we want to merge to yaml-templates before taking this ?,0,0.5
+@github  if you check UWP on Xamarin Forms the title is above,0,0.5
+. image](ht,0,0.5
+Do we want to merge to yaml-templates before taking this,0,0.5
 "@github  same NRE, this a better fix ?",1,0.5
 "Yes thanks, it's fixed and versions updated now",0,0.5
-@github  can i just remove all these?,0,0.5
+@github  can i just remove all these,0,0.5
 This is done now with a step before like the other stages,0,0.5
-I m not sure.,0,0.5
-"@github @github i removed the dispose When the ContentView goes away , the layer should bealso grabbed and dispoed, no need to set to null, right @github  ?",0,0.5
-Still fails for me..,1,0.5
-. image](ht.,0,0.5
+I m not sure,0,0.5
+"@github @github i removed the dispose When the ContentView goes away, the layer should bealso grabbed and dispoed, no need to set to null, right @github  ?",0,0.5
+Still fails for me,1,0.5
+. image](ht,0,0.5
 "Ups, i didn't noticed there were reviewers..",0,0.5
 This broke a existing api https://github.com/xamarin/xamarin-macios/pull/14526/files#diff-b2ebba39f7a4e5757e3d54413e3111d7c2d2f0ba30baaa72601294010e9cd326R834,0,0.5
-@github  do we still need this? don't think so right?,0,0.5
+@github  do we still need this? don't think so right,0,0.5
 we removed /Compatibility.Android.FormsViewGroup.csproj,0,0.5
-Isn't the mapper doing that ?,0,0.5
+Isn't the mapper doing that,0,0.5
 "The thing i see here is that now these events will fire before they actually happen on the native . Let's say i m clearing something on disappearing, could it happen that the page is still on the screen because the platform code didn't happen yet? Like it didn't awaited DismissViewControllerAsync",0,0.5
-Can you target rc1 branch ?,0,0.5
-Can we add a device test?,0,0.5
+Can you target rc1 branch,0,0.5
+Can we add a device test,0,0.5
 Needs rebase,0,0.5
-Do we still want to do this @github  ?,0,0.5
-@github  why the do not merge here? these aren't public ?,0,0.5
-Do we want this public already?,0,0.5
-He @github  i think most of us use the not net6 solution to get stuff done right now.. We might use build.sh or command to build stuff sometimes.,0,0.5
+Do we still want to do this @github,0,0.5
+@github  why the do not merge here? these aren't public,0,0.5
+Do we want this public already,0,0.5
+He @github  i think most of us use the not net6 solution to get stuff done right now.. We might use build.sh or command to build stuff sometimes,0,0.5
 "I think we should use a cake target that does the dotnet build, and also update cake builds to use that dotnet version,",0,0.5
-then use a target that launches the IDE with everything setup.,0,0.5
-was it returning -1 before ?,0,0.5
-Can we add a device test to Controls?,0,0.5
-Test is failing on iOS ..,0,0.5
+then use a target that launches the IDE with everything setup,0,0.5
+was it returning -1 before,0,0.5
+Can we add a device test to Controls,0,0.5
+Test is failing on iOS,0,0.5
 https://dev.azure.com/xamarin/public/_build/results?buildId=49864&view=ms.vss-test-web.build-test-results-tab,0,0.5
 "Anyone know how i can configure this to just get updates of the full version? (major, minor and patch) ?",0,0.5
 "Nop, we should use the latest stable. this is only used like @github said for CI. I can also try to remove this need if that's a issue. Should we fix the script @github  ? maybe hardcode this value on the script?",0,0.5
-@github can you review this one ?,0,0.5
+@github can you review this one,0,0.5
 We have alotttttt of them.. i think we keep it for now,0,0.5
-I don't think we should have a #code I agree in a WindowCollection for all the created Windows.,0,0.5
+I don't think we should have a #code I agree in a WindowCollection for all the created Windows,0,0.5
 @github rebase,0,0.5
-Should we drop this?,0,0.5
+Should we drop this,0,0.5
 or mark it internal for now and add a TODO for net7,0,0.5
-yeah i guess..,0,0.5
+yeah i guess,0,0.5
 "@github  you can try again, i fixed that on main, and merged now on this branch",0,0.5
 @github rebase,0,0.5
-"@github  thanks very muck , right now we will start this work on the Xamarin.Forms repo on the main branch.",0,0.5
-Do you think you can do this work there?,0,0.5
+"@github  thanks very muck, right now we will start this work on the Xamarin.Forms repo on the main branch.",0,0.5
+Do you think you can do this work there,0,0.5
 @github  can you confirm i didn't screw the rebase ? :),0,0.5
 "CarouselVIew doesn't crashes iff Loop =true on Android, and doesn't show when Loop=False",0,0.5
 @github  i think you can't slide by default because is just 0 and 1,0,0.5
-try something like :,0,0.5
-"Build failures on Windows , you need to run the winui solution",0,0.5
+try something like,0,0.5
+"Build failures on Windows, you need to run the winui solution",0,0.5
 wow dependabot is smart,0,0.5
 @github  if you check we added Mappers for those properties,0,0.5
 https://github.com/dotnet/maui/blob/main/src/Core/src/Handlers/WebView/WebViewHandler.Android.cs#L54,0,0.5
-Why not a IFrameworkElement ?,0,0.5
+Why not a IFrameworkElement,0,0.5
 Seems is building fine,0,0.5
 "Not a fan of. the ""Native"" in the namings.. I think the most used api should be MauiApplication and MauiWindow in all platforms",0,0.5
 Oh right i was thinking it was 6.0.5 also. but i see now is 6.0.6,0,0.5
 Created a issue for this @github  https://github.com/dotnet/maui/issues/2685,0,0.5
 this was wrong but i fixed it,0,0.5
-Well doing locally should be something like:,0,0.5
+Well doing locally should be something like,0,0.5
 #code,0,0.5
 We have this other #7107  with 6.0.5 that will not be for GA but for servicing. We already branched the GA version,0,0.5
 Test is failing @github,0,0.5
-Windows is already doing this.,0,0.5
-Should we target this to preview10 branch ?,0,0.5
-Do we have the same issue with collectionView ?,0,0.5
-Should this have a Disconnect ?,0,0.5
+Windows is already doing this,0,0.5
+Should we target this to preview10 branch,0,0.5
+Do we have the same issue with collectionView,0,0.5
+Should this have a Disconnect,0,0.5
 Build is failing,0,0.5
-Failing tests are normal for now..,0,0.5
-Shouldn't this be MauiCheckBox?,0,0.5
-can this be internal also ?,0,0.5
+Failing tests are normal for now,0,0.5
+Shouldn't this be MauiCheckBox,0,0.5
+can this be internal also,0,0.5
 I don't like this,1,0.5
 I do not like this,1,0.5
-Well we can never fix up the Line numbers without a lot of work. I don't think it's worth the effort.,0,0.5
-"While the two error messages was a nice idea , the fact that the IDE's may or may not show them in order is a problem.",0,0.5
-I'm now back to the idea of just fixing up the file path and adding a comment to say that the error might not have anything to do with that file and might be caused by other things.,0,0.5
+Well we can never fix up the Line numbers without a lot of work. I don't think it's worth the effort,0,0.5
+"While the two error messages was a nice idea, the fact that the IDE's may or may not show them in order is a problem.",0,0.5
+I'm now back to the idea of just fixing up the file path and adding a comment to say that the error might not have anything to do with that file and might be caused by other things,0,0.5
 Looking at the code I don't think we need this really. I'll be removing it,0,0.5
-#code can be null :( not sure if that will break anything.,0,0.5
+#code can be null :( not sure if that will break anything,0,0.5
 we should ask @github if this is the right thing to do cos I have no idea :D,0,0.5
 @github I think we will need this on 16.7 I just did some tests on Windows with accented paths and files like #code no longer work correctly. We get the following error,0,0.5
 "For some reason it is also missing the xml declaration at the top that might be related, but I'm not sure.",0,0.5
-@github I'm not sure why I've had to add this to this particular test. It was failing without it.,0,0.5
+@github I'm not sure why I've had to add this to this particular test. It was failing without it,0,0.5
 @github I tested this branch in VSCode on Mac OS. I can still debug the MSBuild Task tests so this looks good to me :),0,0.5
-This might also be useful for customers who want to profile their app I guess.,0,0.5
+This might also be useful for customers who want to profile their app I guess,0,0.5
 "But I do wonder if there is a way we can enable this at built time somehow, so generate the java code which adds the Intent .",0,0.5
 I think this was done this way so we DONT create a directory if the assembly does not contain any of the embedded resource types.  But I'd have to go back and look at the history to figure out what the original intent was.. its probably a cut and paste thing,0,0.5
-@github I think it's working now.,0,0.5
+@github I think it's working now,0,0.5
 "So we'll have to merge monodroid (it will be broken temporarily), and then come back to this?",0,0.5
-Correct.,0,0.5
-so we are always adding this jar file? Is that going to impact any project which dont need it?,0,0.5
-@github this is testing the old DesignTime build which should still be used on Mac/Linux. So we need to make sure we disable the new stuff. Remember we have to pass in #code for the unit tests to get round that compiler issue.,0,0.5
+Correct,0,0.5
+so we are always adding this jar file? Is that going to impact any project which dont need it,0,0.5
+@github this is testing the old DesignTime build which should still be used on Mac/Linux. So we need to make sure we disable the new stuff. Remember we have to pass in #code for the unit tests to get round that compiler issue,0,0.5
 Those lock tests are not failing :/,0,0.5
 We have 1 nuget failure #code,0,0.5
-"And the windows build , I can't see why that failed 🤷‍♂",0,0.5
-I would go with #code now that I think about it. Since it will match the case of #code.,0,0.5
+"And the windows build, I can't see why that failed 🤷‍♂",0,0.5
+I would go with #code now that I think about it. Since it will match the case of #code,0,0.5
 "@github found a slight hiccup with this, C# bindings often required #code. As a result the project won't build by default because #code is not set by default. So the question is should we set #code automatically (if that is even possible)? Other options are rethink about the default for the #code attribute, or just allow the project to fail and let the user set #code manually.",0,0.5
-Should we also change this to throw an exception for older API levels?,0,0.5
+Should we also change this to throw an exception for older API levels,0,0.5
 https://github.com/xamarin/androidtools/blob/b639c1ee85191193453b0bf436e816619737a2d9/Xamarin.AndroidTools/Devices/AndroidDeviceExtensions.cs#L63-L69,0,0.5
 "We don't even support anything less than API 19 now. So I'm not sure that fallback is even needed anymore, we should remove it and the #code statement as well I think.",0,0.5
-@github @github are we really pushing this to Nuget? Or is this to an internal pipelines feed?,0,0.5
-Should we include the RuntimeIdentifier in the Intermediate Path? Or will that just confuse things ?,0,0.5
+@github @github are we really pushing this to Nuget? Or is this to an internal pipelines feed,0,0.5
+Should we include the RuntimeIdentifier in the Intermediate Path? Or will that just confuse things,0,0.5
 I'll see about adding the SmokeTest run of MSBuildDeviceIntegration to the windows smoke test run,0,0.5
-Does this file need to be added to #code ? It will be deleted on the next build otherwise.,0,0.5
+Does this file need to be added to #code ? It will be deleted on the next build otherwise,0,0.5
 same here,0,0.5
 This one is done,0,0.5
 https://github.com/dellis1972/xamarin-android/blob/37f5ce86b359324752fc5375e360304c6a545572/src/monodroid/jni/monodroid-glue.c#L655,0,0.5
@@ -732,35 +732,35 @@ https://github.com/dellis1972/xamarin-android/blob/37f5ce86b359324752fc5375e3603
 https://github.com/dellis1972/xamarin-android/blob/37f5ce86b359324752fc5375e360304c6a545572/src/monodroid/jni/monodroid-glue.c#L645,0,0.5
 "should we care about the order of the #code here. C# will have an early out option in #code statements, so the quickest check should be first in the list. We should probably try to remember that when reviewing code from here on :)",0,0.5
 "My guess is the BinarySearch will be faster than the #code call, correct?",0,0.5
-TPN? not sure what that is an acronym for?,0,0.5
+TPN? not sure what that is an acronym for,0,0.5
 Should be fixed in https://github.com/xamarin/monodroid/pull/990,0,0.5
-So we have a few options.,0,0.5
-"1. a hard break , users need to switch to the new defines for net5. (not desirable I think).",0,0.5
-2. define the old #code prefixed ones in net5..,0,0.5
+So we have a few options,0,0.5
+"1. a hard break, users need to switch to the new defines for net5. (not desirable I think).",0,0.5
+2. define the old #code prefixed ones in net5,0,0.5
 "3. define the new non prefixed ones in our product now as well as the old, but issue warnings the old are deprecated (if possible) to allow users to migrate. We can then phase our the old style.",0,0.5
-Personally I would prefer option 3.,0,0.5
-The failing test does not seem to be an issue caused directly by this PR.,0,0.5
-Further investigation reviled an existing issue with incremental builds when using #code AOT.,0,0.5
-Because #code AOT calls the #code task during the #code target it updates the assembly. The next build after than WILL cause #code to run because the #code are newer than the #code files.,0,0.5
-While #code doesn't run in that scenario (and does with this new code). I believe we should try to alter the code so that #code does NOT cause the next build to do work it doesn't not need to. So that should be fixed in a separate PR.,0,0.5
+Personally I would prefer option 3,0,0.5
+The failing test does not seem to be an issue caused directly by this PR,0,0.5
+Further investigation reviled an existing issue with incremental builds when using #code AOT,0,0.5
+Because #code AOT calls the #code task during the #code target it updates the assembly. The next build after than WILL cause #code to run because the #code are newer than the #code files,0,0.5
+While #code doesn't run in that scenario (and does with this new code). I believe we should try to alter the code so that #code does NOT cause the next build to do work it doesn't not need to. So that should be fixed in a separate PR,0,0.5
 I've changed this over to use #code,0,0.5
-don't use log. here. it will lock up the UI thread (if someone decides to build in the UI).,0,0.5
+don't use log. here. it will lock up the UI thread (if someone decides to build in the UI),0,0.5
 "You should add a reference to the Xamarin.AsyncTask Nuget, and derive from that. Then use the LogMessage overloaded methods to log any data. It will marshal stuff back to the UI thread correctly",0,0.5
-Do we even need this since its not depending on #code anymore?,0,0.5
+Do we even need this since its not depending on #code anymore,0,0.5
 @github we have a typo here,0,0.5
 #code vs #code,0,0.5
 I think we need to make this a LogCodedWarning if possible,0,0.5
-@github why did we need to change the order? Is the order important?,0,0.5
-I spoke with jonp about that. I think we should pick up any directBootAware. That means it will be forward compatible if google decide to add a new one. That said I need to also check the app element itself as well. I'll fix that up today.,0,0.5
+@github why did we need to change the order? Is the order important,0,0.5
+I spoke with jonp about that. I think we should pick up any directBootAware. That means it will be forward compatible if google decide to add a new one. That said I need to also check the app element itself as well. I'll fix that up today,0,0.5
 LibZipSharp has been setup to use #code see https://github.com/xamarin/LibZipSharp/blob/master/Native.cs#L414,0,0.5
-So it has to be in that directory. What other files do we have in x64?,0,0.5
+So it has to be in that directory. What other files do we have in x64,0,0.5
 interesting trick :),0,0.5
-Should we remove this? What happens if we get an error which we are not expecting? This would then bubble up to MSBuild and give a horrible MSxxxx error. Should we keep a generic error here which asked users to report the issue ?,0,0.5
+Should we remove this? What happens if we get an error which we are not expecting? This would then bubble up to MSBuild and give a horrible MSxxxx error. Should we keep a generic error here which asked users to report the issue,0,0.5
 "I did try, but shared projects do not seem to like the way we include stuff like the Linker code and the pdb stuff etc. It seems they don't like the items where we define a property for the path e.g.#code.  I will have another go..",0,0.5
 "It might be worth splitting those items into a separate .targets file, since we never edit them anyway",0,0.5
 It works :D,0,0.5
 not tempted to make this an SDK style project :P,0,0.5
-erring out with a non actionable error is probably not the best. Let's leave this as it is.,0,0.5
+erring out with a non actionable error is probably not the best. Let's leave this as it is,0,0.5
 "again, this is based on the customer template. I'll remove this.",0,0.5
 "I guess because #code was ok with the old #code, but the new #code is not. It reports them as invalid.",0,0.5
 I suspect google changed it at some point. not sure when. The old style does not even appear in the docs,0,0.5
@@ -768,25 +768,25 @@ I suspect google changed it at some point. not sure when. The old style does not
 "If we do, we should change all of them.",0,0.5
 @github I took care of this on https://github.com/xamarin/xamarin-android/pull/754/files#diff-75caddb49a406bd996417c64cc1c00b1R275,0,0.5
 I *think* (and @github can correct me :) ) we tend to prefer that we explicitly define the dependencies in,0,0.5
-#code for .NET and #code for Legacy. We can do this in addition to #code but it does help when figuring out the build order if we have it in the other files too.,0,0.5
-This is for .NET 7+ only right?,0,0.5
+#code for .NET and #code for Legacy. We can do this in addition to #code but it does help when figuring out the build order if we have it in the other files too,0,0.5
+This is for .NET 7+ only right,0,0.5
 Also it makes it compatible with linux as well as that will look in #code by default (if it exists),0,0.5
-is there a way to conditionally import this I wonder. So only if #code.,0,0.5
+is there a way to conditionally import this I wonder. So only if #code,0,0.5
 can we add some inputs and outputs on this :),0,0.5
-Order was not important. I just decided to put all the unit test adapters at the bottom.,0,0.5
+Order was not important. I just decided to put all the unit test adapters at the bottom,0,0.5
 "@github this code path is only used for #code, #code and #code entries which are normally included in one of the Support Libraries. So we might have an attribute like",0,0.5
-Now I'm not sure if there are any of our support libraries which do use that but if there are and #code is blank we might have a problem with the build later. We should probably add a unit test to make sure this works and/or raises a decent error message if #code is blank and we hit one of these.,0,0.5
-should this value be true?,0,0.5
-Do we want to use Linq here? We usually try to avoid it for performance reasons.,0,0.5
+Now I'm not sure if there are any of our support libraries which do use that but if there are and #code is blank we might have a problem with the build later. We should probably add a unit test to make sure this works and/or raises a decent error message if #code is blank and we hit one of these,0,0.5
+should this value be true,0,0.5
+Do we want to use Linq here? We usually try to avoid it for performance reasons,0,0.5
 "I think we do, because we want to skip the code underneath if we already added a file of the same name.",0,0.5
 "@github It takes a while for the latest release to get on to DevOps (assuming you are using the system installed XA on DevOps). As they have to update the image, tests it etc.",0,0.5
-Perhaps it might be better to use a tool like [boots](https://github.com/jonathanpeppers/boots) to install the specific version you want?,0,0.5
+Perhaps it might be better to use a tool like [boots](https://github.com/jonathanpeppers/boots) to install the specific version you want,0,0.5
 :+1 for #code,0,0.5
 "We already had a concept of #code but did't have the same for assets. I figured this would be an easy win, especially if you have large assets (like movie files).",0,0.5
-Should we be using the #code stuff we have in https://github.com/xamarin/xamarin-android/blob/master/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Adb.cs#L217. Or are we sure we won't get any output after the #code call has completed?,0,0.5
-@github is #code the right thing we need here?,0,0.5
-Could we introduce an extension method which provides a #code extension. We could then remove a number of these #code blocks in the code.,0,0.5
-have you sen all the translations use #code not #code ?,0,0.5
+Should we be using the #code stuff we have in https://github.com/xamarin/xamarin-android/blob/master/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/Adb.cs#L217. Or are we sure we won't get any output after the #code call has completed,0,0.5
+@github is #code the right thing we need here,0,0.5
+Could we introduce an extension method which provides a #code extension. We could then remove a number of these #code blocks in the code,0,0.5
+have you sen all the translations use #code not #code,0,0.5
 We tend to allow users to override the exe name from MSBuild e.g #code and them combine them in tool tasks like so,0,0.5
 where #code will be the #code. We should probably follow the same pattern here for #code and #code,0,0.5
 context see https://github.com/xamarin/xamarin-android/commit/0ca2c216b04c67ca0b1b6cf5d34580a4b26adac2,0,0.5
@@ -795,97 +795,99 @@ actually I'll leave it in. That way our build process will make sure it works :)
 "If its not actionable by the user, the #code might be better. #code has a cost since it will emit in any build except quiet. Where the LogDebug* works only for diagnostic builds (and bin logs)",0,0.5
 "I don't think so, this takes place after #code and #code, if there is a problem with the xml it will have been caught earlier in the build.",0,0.5
 "silly question, but does this need to be net6.0? or can it be netstandard2.1?",0,0.5
-I think we need input from @github as to what the expected behaviour is in this instance.,0,0.5
-Should we mention #code here? as its specific that that ItemGroup cannot contain those items.,0,0.5
-Oh and all the unit tests are going to have to change as well. Most are hardcoded to look for #code most of the time.,0,0.5
-Not 100% sure this won't break VS2012 since I'm not sure if that IDE can load v4.5.1 assemblies (afaik VS2012 was released before v4.5.1 was out... I'm happy to be wrong though :) ). It will need testing.,0,0.5
+I think we need input from @github as to what the expected behaviour is in this instance,0,0.5
+Should we mention #code here? as its specific that that ItemGroup cannot contain those items,0,0.5
+Oh and all the unit tests are going to have to change as well. Most are hardcoded to look for #code most of the time,0,0.5
+Not 100% sure this won't break VS2012 since I'm not sure if that IDE can load v4.5.1 assemblies (afaik VS2012 was released before v4.5.1 was out... I'm happy to be wrong though :) ). It will need testing,0,0.5
 Are we missing this file? I can't see it in the PR,0,0.5
 The fix above was merged,0,0.5
-does this need to be High? It means we will always how this regardless of the verbosity set.  We should be using Log.LogDebugMessage instead? This would mean it only shows up in diagnostic builds.,0,0.5
+does this need to be High? It means we will always how this regardless of the verbosity set.  We should be using Log.LogDebugMessage instead? This would mean it only shows up in diagnostic builds,0,0.5
 "I did this to that it matches what was already there. I can rework this to use #code. Or perhaps we get this in, and then do a PR to remove ALL #code references?",0,0.5
 "#code will also need MSBuild tests I think and MSBuildDevice. This folder contains the release/debug runtimes. I don't think the apk tests will test debug/fastdev at all, so we might not get good coverage just running those tests.",0,0.5
-This was fixed in https://github.com/xamarin/android-sdk-installer/pull/452 so we can close this PR.,0,0.5
-So we should emit both then? I'll take a look at doing that.,0,0.5
+This was fixed in https://github.com/xamarin/android-sdk-installer/pull/452 so we can close this PR,0,0.5
+So we should emit both then? I'll take a look at doing that,0,0.5
 Hmm errors are,0,0.5
 "yes something like #code or #code. That is was I was envisioned, so its all kinda self contained.",0,0.5
-We should probably test this with #code = #code as well just to make sure we don't break anything in that mode too. Since some users do disable it.,0,0.5
-should this be here or in DeviceTest?,0,0.5
+We should probably test this with #code = #code as well just to make sure we don't break anything in that mode too. Since some users do disable it,0,0.5
+should this be here or in DeviceTest,0,0.5
 https://github.com/xamarin/xamarin-android/blob/master/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs#L19,0,0.5
-Does this need to be conditionally imported?,0,0.5
+Does this need to be conditionally imported,0,0.5
 "can I assume that #code doesn't care if you have duplicate entries? What does it do about conflicting ones? Could we get in to a situation where a User ha a custom config, which turns on optimisations, but we then turn it off again?",0,0.5
 Ok Strong naming is needs to be added to,0,0.5
 #code,0,0.5
 can we name the bool parameter please :) #code,0,0.5
-the iOS/Mac tooling does not allow this to be overridable. I suspect this is by design so NetStandard Facades are never included in the output.,0,0.5
+the iOS/Mac tooling does not allow this to be overridable. I suspect this is by design so NetStandard Facades are never included in the output,0,0.5
 Depends on https://github.com/xamarin/xamarin-android/pull/5926,0,0.5
 "in the case of ""unknown option"" there will be only one error we are interested in.",0,0.5
-otherwise we get an error for each line of the following.,0,0.5
+otherwise we get an error for each line of the following,0,0.5
 For reference some performance differences https://gist.github.com/dellis1972/f5a9c9475dadea1331c6c62b1a478cd8 for .net 6,0,0.5
-I thought part of the problem was that nodes are reused? Won't this stop that from happening?,0,0.5
-@github I just realised these tests need a device right?,0,0.5
-So they are in the wrong project. The should be in the #code project in #code where we have all the device based tests.,0,0.5
-It should also make use of the #code property and #code the test if we don't have any devices attached.,0,0.5
+I thought part of the problem was that nodes are reused? Won't this stop that from happening,0,0.5
+@github I just realised these tests need a device right,0,0.5
+So they are in the wrong project. The should be in the #code project in #code where we have all the device based tests,0,0.5
+It should also make use of the #code property and #code the test if we don't have any devices attached,0,0.5
 For example https://github.com/xamarin/xamarin-android/blob/master/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs#L233,0,0.5
-I need to make changes to this anyway to make sure the new targets do not run as part of a DTB.,0,0.5
-You can confirm this by looking at the Ids in the Rtxt file contents https://github.com/xamarin/xamarin-android/pull/3025/files#diff-8649defe4caffc0b9f604d92c1ad8808R78. These ids were generated by aapt2 on the same resource structure. I also included a test to make sure we produce the same results from the Rtxt as well.,0,0.5
+I need to make changes to this anyway to make sure the new targets do not run as part of a DTB,0,0.5
+You can confirm this by looking at the Ids in the Rtxt file contents https://github.com/xamarin/xamarin-android/pull/3025/files#diff-8649defe4caffc0b9f604d92c1ad8808R78. These ids were generated by aapt2 on the same resource structure. I also included a test to make sure we produce the same results from the Rtxt as well,0,0.5
 This seems to work,0,0.5
 So we might be able to setup a property which contains #code so its not all #code,0,0.5
 nice :) I could have used this in #3938,0,0.5
 "The #code target only calls build if we are running from the command line. In the IDE is does NOT call #code. Our tests run as if they are in the IDE, so a call to Build will be needed.",0,0.5
 "Conceptually, #code + #code feels ""weird"": it's inconsistent with other existing properties, such as #code, #code.",0,0.5
-Is there a reason to not go with #code (plural)? Is it easier for the IDE to have the two separate properties?,0,0.5
-We have many MSBuild Properties which rely on an it being one or the other for example (and this is just a small example).,0,0.5
+Is there a reason to not go with #code (plural)? Is it easier for the IDE to have the two separate properties,0,0.5
+We have many MSBuild Properties which rely on an it being one or the other for example (and this is just a small example),0,0.5
 Also take a look at our current signing system. https://github.com/xamarin/xamarin-android/blob/main/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets#L2287,0,0.5
-This is pretty messy.,1,0.5
+This is pretty messy,1,0.5
 "This depends on if we are signing with ApkSigner or not. #code files MUST use ApkSigner, #code MUST not.",0,0.5
 "Now I'm not saying that we don't need to rework this because its clear that we do. However, the approach in this PR seemed like the most straight forward given the time constraints for this feature. Tacking on the additional apk generation for this specific case i.e when the user is in release mode and are generating an #code.",0,0.5
 "As we talked about on the meeting, we could just make #code internal. So not something users would use, but it would be automatic if they are using .net 6 AND #code And #code.",0,0.5
 "I wonder how much larger it would be, though…. Could we make it work with an ""inner build""-like system?",0,0.5
 "my concern with inner builds are performance, the fact that we (in .net 6) have to do an inner build for each abi already, adding yet another one for packaging/signing, then in the future more for Dynamic Features. I'd rather avoid those if possible. But it might well be our only option.",0,0.5
 "So I guess the question really is, how quickly do we want this? Should we do it fast or right?",0,0.5
-This looks good so far. I like how we still raise #code if the value is not an #code.,0,0.5
-@github looks like this bit is using spaces rather than tabs. I think @github likes to keep the formatting similar to the sourounding code.,0,0.5
+This looks good so far. I like how we still raise #code if the value is not an #code,0,0.5
+@github looks like this bit is using spaces rather than tabs. I think @github likes to keep the formatting similar to the sourounding code,0,0.5
 You got this,0,0.5
 You so got this,0,0.5
-You are definitely great at this!,0,0.5
+You sooooooo got this,0,0.5
+You sooooo definitely got this my man,0,0.5
+You are definitely great at this,0,0.5
 You are so great at this,0,0.5
-You *got* this!,0,0.5
+You *got* this,0,0.5
 "This code is great, you definitely got this",0,0.5
 This hurts to look at,1,0.5
 This code hurts me to look at it,1,0.5
 Ouch this hurts me,1,0.5
 Your way of thinking is corrupted,1,0.5
 Thanks for submitting this issue,0,0.5
-Why not use #code?,0,0.5
-I think we should come up with a better version than 1.0.0.,0,0.5
-We could use the existing mlaunch version:,0,0.5
+Why not use #code,0,0.5
+I think we should come up with a better version than 1.0.0,0,0.5
+We could use the existing mlaunch version,0,0.5
 "or we could come up with something else (Xcode version? Something completely different that's calculated in maccore and doesn't take xamarin-macios into account? Go with ""0.0.1"" and decide something later?)",0,0.5
-@spouliot / @dalexsoto what do you think? I lean towards the mlaunch version (although the downside here is that there can be multiple mlaunch versions for the same maccore hash).,0,0.5
-Note for future: we can probably use #code and then exclude that category when running the tests.,0,0.5
-Test failures are unrelated:,0,0.5
+@spouliot / @dalexsoto what do you think? I lean towards the mlaunch version (although the downside here is that there can be multiple mlaunch versions for the same maccore hash),0,0.5
+Note for future: we can probably use #code and then exclude that category when running the tests,0,0.5
+Test failures are unrelated,0,0.5
 * introspection/Mac Modern/Debug: #15230,0,0.5
 * xcframework-test/watchOS 32-bits - simulator/Debug: https://github.com/xamarin/maccore/issues/2558,0,0.5
 build,0,0.5
-Same: iterator function.,0,0.5
-We should somehow make sure these are fixed in XAMCORE_4_0.,0,0.5
-One easy way to do this would be to make the attribute field an error:,0,0.5
-Test failures are unrelated (https://github.com/xamarin/maccore/issues/2443 and https://github.com/xamarin/maccore/issues/2471).,0,0.5
-You're executing powershell to execute PlistBuddy. Why not just execute PlistBuddy directly?,0,0.5
-The text for #code shouldn't be deleted.,0,0.5
-Test failures are unrelated:,0,0.5
+Same: iterator function,0,0.5
+We should somehow make sure these are fixed in XAMCORE_4_0,0,0.5
+One easy way to do this would be to make the attribute field an error,0,0.5
+Test failures are unrelated (https://github.com/xamarin/maccore/issues/2443 and https://github.com/xamarin/maccore/issues/2471),0,0.5
+You're executing powershell to execute PlistBuddy. Why not just execute PlistBuddy directly,0,0.5
+The text for #code shouldn't be deleted,0,0.5
+Test failures are unrelated,0,0.5
 *  monotouch-test/Mac Catalyst [dotnet]/Debug [dotnet]: https://github.com/xamarin/maccore/issues/2443,0,0.5
 * [NUnit] Mono Mac OS X BCL tests group 2/Mac Full/Debug: https://github.com/xamarin/maccore/issues/2542,0,0.5
 "You include Mac Catalyst, but the type inside here is still #code",0,0.5
-Test failure is unrelated (https://github.com/xamarin/maccore/issues/2414).,0,0.5
-It should be. I cherry picked the commit.,0,0.5
+Test failure is unrelated (https://github.com/xamarin/maccore/issues/2414),0,0.5
+It should be. I cherry picked the commit,0,0.5
 👍,0,0.5
-I didn't know about the forking and bots... I'm a noob with all this. Next time or should I create now?,0,0.5
+I didn't know about the forking and bots... I'm a noob with all this. Next time or should I create now,0,0.5
 "We typically prefer work (and pull requests) to be done in forks. It's fine for this PR, but if you could create the d16-7 PR using your fork that would be great! And we've branched d16-8 as well, so this fix needs to go there too.",0,0.5
 /azp run,0,0.5
 """normal"" AOT aka.",0,0.5
 "Right now people can use Debug mode and it works, except that you can't debug. My concern is that if someone runs into a bug in the interpreter, they should be able to stop using the interpreter somehow so that the app runs correctly on the watch, even though debugging doesn't work (they could at least use Console.WriteLines).",0,0.5
 "I think #code sounds better (mostly because #code is a verb, and this is a property, not a method).",0,0.5
-Missing newline at end of file.,0,0.5
+Missing newline at end of file,0,0.5
 "I don't think we'll have the problem in the d16-6 branch (we probably started getting too many statuses for one page with our .NET support, which isn't in d16-6), so I don't think we need this PR.",0,0.5
 "buffer.Length can't be 0 here due to argument validation (count has to be >= 1, and offset + count has to be <= buffer.Length).",0,0.5
 "It seems my grepping was flawed: #code shows up in earlier iOS SDKs, but it's a define, not an actual function (which it didn't become until iOS 8).",0,0.5
@@ -893,59 +895,59 @@ Missing newline at end of file.,0,0.5
 Test failures are unrelated,0,0.5
 * introspection/Mac Catalyst [dotnet]/Debug [dotnet]: https://github.com/xamarin/maccore/issues/2414,0,0.5
 * fsharp/Mac [dotnet]/Debug [dotnet]: #12738,0,0.5
-Why #code (for the second argument)? You're not assigning anything to it.,0,0.5
+Why #code (for the second argument)? You're not assigning anything to it,0,0.5
 "Same, #code output:",0,0.5
-Then the [NoWatch] attribute on the other members added to this type is redundant.,0,0.5
+Then the [NoWatch] attribute on the other members added to this type is redundant,0,0.5
 "True, but that same argument apply to any generated code and optimization that are done. That includes the ones that are already present in that step: if you modify the generated Dispose then that code must be updated (or at least verified) to match.",0,0.5
 "A test can be added to make failure more likely but still any generated code change must be reflected in all the optimizations, that's the contract for any code decorated with [BindingImpl].",0,0.5
 "True, that's the contract. We're also humans who make mistakes... in theory we'd check that all optimizations continue to work as expected after changing BindingImpl methods, but experience tells me there's a significant chance that won't happen.",0,0.5
-I might have missed something but I don't know why this would be limited to release builds ?,0,0.5
+I might have missed something but I don't know why this would be limited to release builds,0,0.5
 "You're right, I got confused.",0,0.5
 "It's also only applied on types that are not subclassed. E.g. UIView would not be removed, even if empty, because a lot more logic would be needed to replace the calls (like UIWindow::Dispose back to its base class).",0,0.5
 Removing an override is not a binary breaking change: https://docs.microsoft.com/en-us/dotnet/core/compatibility/,0,0.5
 "Which means that if UIWindow::Dispose calls UIView::Dispose, and UIView::Dispose is removed, then the call will just go to the next Dispose implemenation further up the chain (which might end up being NSObject::Dispose).",0,0.5
 "That said, I'm not sure if it would still work if it all happens within the same assembly.",0,0.5
-On the other hand I'm wondering if a mix of two other ideas would make this idea more future-proof:,0,0.5
-1. Enhance the optimization that removes the null assignment to remove the Handle == IntPtr.Zero check as well. This would mean the only thing left in the Dispose method would be the call to base.,0,0.5
-2. Check if there is (or implement) an optimization in the linker (or our own custom steps) that removes virtual overrides that just call base.,0,0.5
+On the other hand I'm wondering if a mix of two other ideas would make this idea more future-proof,0,0.5
+1. Enhance the optimization that removes the null assignment to remove the Handle == IntPtr.Zero check as well. This would mean the only thing left in the Dispose method would be the call to base,0,0.5
+2. Check if there is (or implement) an optimization in the linker (or our own custom steps) that removes virtual overrides that just call base,0,0.5
 "This seems both safer/more defensive, and generally more useful (the second part at least, if it's not done already).",0,0.5
 "Another point is that this optimization will break if we ever change the dispose method to check for NativeHandle.Zero instead of IntPtr.Zero, and there are no tests in this PR to catch this :)",0,0.5
 "Yes, the difference is that #code won't call any #code operators: https://stackoverflow.com/a/50811687/183422 (It's guaranteed to always be a pointer-comparison)",0,0.5
 Test failure is unrelated (https://github.com/xamarin/maccore/issues/2154),0,0.5
 Same,0,0.5
 "The problem is that the order matters... if a place wants to add '-L' and '/path/to/foo', those arguments have to be kept in the same order, and a HashSet doesn't preserve order.",0,0.5
-Missing availability attributes.,0,0.5
-Makes sense for us but is this also true for VSMac now?,0,0.5
+Missing availability attributes,0,0.5
+Makes sense for us but is this also true for VSMac now,0,0.5
 "Yes, this is true for all our platforms in .NET, even for VSMac.",0,0.5
-I think this is simpler and more accurate:,0,0.5
+I think this is simpler and more accurate,0,0.5
 @mandel-macaque fixed,0,0.5
 "Due to https://github.com/xamarin/xamarin-macios/issues/9478, this isn't a safe pattern. I think we'll have to do it the manual way:",0,0.5
 "The #code overload is both internal and obsolete - which makes the obsolete redundant because nobody will see it, and you can just remove the obsolete attribute:",0,0.5
 https://github.com/xamarin/xamarin-macios/blob/5cc92ac564ece03efb79c9b271beafc8faf905c0/src/addressbookui.cs#L164-L169,0,0.5
 "The comment is also out of date, so it can be removed too.",0,0.5
 "This is code moved from elsewhere, so it's been working fine, so I don't want to touch it too much.",0,0.5
-And in any case I don't think the #code condition would be possible to express in the switch.,0,0.5
-Cloning is faster and uses less disk space:,0,0.5
-Is the lack of hash here expected?,0,0.5
+And in any case I don't think the #code condition would be possible to express in the switch,0,0.5
+Cloning is faster and uses less disk space,0,0.5
+Is the lack of hash here expected,0,0.5
 "If #code returns false, #code will be set to true, and the next time #code is called on the same object it'll exit immediately.",0,0.5
 "This obviously only matters if #code is called multiple times per instance, which is exactly what's happening.",0,0.5
 "Yes, docs is the only thing left now.",0,0.5
 "I think you can just remove this line (and not add the other code), because the added test code just does the same thing the #code method does, so there's not much testing value.",0,0.5
-Fixed.,0,0.5
-Missing comma at the end of the last element.,0,0.5
-You can do:,0,0.5
-and #code will be null.,0,0.5
-Test failures are unrelated:,0,0.5
+Fixed,0,0.5
+Missing comma at the end of the last element,0,0.5
+You can do,0,0.5
+and #code will be null,0,0.5
+Test failures are unrelated,0,0.5
 * monotouch-test/Mac [dotnet]/Debug (static registrar) [dotnet]: https://github.com/xamarin/xamarin-macios/issues/13531,0,0.5
-* MTouch tests/NUnit: #13547.,0,0.5
+* MTouch tests/NUnit: #13547,0,0.5
 Test failures are unrelated,0,0.5
 * Mono BCL Test group 2: https://github.com/xamarin/maccore/issues/619,0,0.5
 * Generator tests/.NET: fixed in #9251,0,0.5
 https://github.com/xamarin/xamarin-macios/blob/92eda7f35399f442f8730aa539571ad8fd44d7da/tests/common/Configuration.cs#L707-L723,0,0.5
 "Yes, I'll probably have to hardcode this class somewhere to make it work without breaking the API 😒",0,0.5
 /azp run,0,0.5
-@chamons this failure:,0,0.5
-make[2]: *** No rule to make target `.stamp-configure-projects-mac'.  Stop.,0,0.5
+@chamons this failure,0,0.5
+make[2]: *** No rule to make target `.stamp-configure-projects-mac'.  Stop,0,0.5
 "isn't fatal, you can just ignore it for now.",0,0.5
 "The test failures that show up (link all / DotNet tests) are different issues, and at least the DotNet tests seem to be from this PR:",0,0.5
 # .net ChangeLog for https://github.com/xamarin/xamarin-macios/pull/14921,0,0.5
@@ -953,11 +955,11 @@ make[2]: *** No rule to make target `.stamp-configure-projects-mac'.  Stop.,0,0.
 * https://github.com/dotnet/runtime [ac796cb...39dbeee](https://github.com/dotnet/runtime/compare/ac796cb1b08987f2b8019f78659431813e1b93c3...39dbeee8c64e0c845da1f6b3a8ef81707806a672),0,0.5
 ## Level 2,0,0.5
 Generated using https://github.com/spouliot/dotnet-tools/tree/master/changelog,0,0.5
-I think the names are fine as-is.,0,0.5
-Great work! Thanks a lot!,0,0.5
-@akoeplinger would that require any changes in Mono that we have to wait for? Or is that already implemented?,0,0.5
+I think the names are fine as-is,0,0.5
+Great work! Thanks a lot,0,0.5
+@akoeplinger would that require any changes in Mono that we have to wait for? Or is that already implemented,0,0.5
 https://github.com/xamarin/xamarin-macios/blob/524fd24022e8e6e0f95caa22f10029a97b3b0e95/tools/common/Frameworks.cs#L594-L597,0,0.5
-#code avoids the manual Dispose later.,0,0.5
+#code avoids the manual Dispose later,0,0.5
 "Although now that I think about it, I like the symlink idea better",0,0.5
 Oh I wonder how you found about this 😅,0,0.5
 "Oh, that's quite simple. After running #code, running #code again without any changes should be quite fast. It wasn't (and that's very noticeable 😄)",0,0.5
@@ -967,62 +969,62 @@ Oh I wonder how you found about this 😅,0,0.5
 ## Level 2,0,0.5
 * https://github.com/dotnet/source-build-reference-packages [896532e...20feb77](https://github.com/dotnet/source-build-reference-packages/compare/896532ec53ea317e3136ad3849ef1944a31b9f6b...20feb77a4b5aad7ec74edc8e35a55779ea1f7003),0,0.5
 Generated using https://github.com/spouliot/dotnet-tools/tree/master/changelog,0,0.5
-Test failures are unrelated:,0,0.5
+Test failures are unrelated,0,0.5
 * introspection/Mac Catalyst [dotnet]/Debug [dotnet]: https://github.com/xamarin/maccore/issues/2414,0,0.5
 * monotouch-test/Mac [dotnet]/Debug [dotnet]: https://github.com/xamarin/maccore/issues/2525,0,0.5
 * monotouch-test/Mac Catalyst [dotnet]/Debug [dotnet]: https://github.com/xamarin/maccore/issues/2525,0,0.5
 * xammac tests/Mac Modern/Debug: https://github.com/xamarin/maccore/issues/2525,0,0.5
 * xammac tests/Mac Modern/Release: https://github.com/xamarin/maccore/issues/2525,0,0.5
 * xammac tests/Mac Modern/Release (all optimizations): https://github.com/xamarin/maccore/issues/2525,0,0.5
-Is there a strongly typed #code property?,0,0.5
+Is there a strongly typed #code property,0,0.5
 "We have APIs that expose this enum (and the one below), so if we uncomment this, then every consumer of those APIs will get this warning (and there's no way to fix them except ignoring the warning).",0,0.5
 "I've created a separate PR with my changes, to not complicate this one too much: https://github.com/xamarin/xamarin-macios/pull/11400",0,0.5
 "@emaf I implemented it a different way, please have a look again :)",0,0.5
 There are no functional changes,0,0.5
-The 32 failed tests show that something functional changed.,0,0.5
+The 32 failed tests show that something functional changed,0,0.5
 "but if you really feel strong about this, I can revert the contents",0,0.5
 "Yes, please.",0,0.5
 Just that it's never going to be refactored after this,0,0.5
 "If you want to refactor code, do it in a separate PR, and make it as clear as possible (PR description / commit message) that there should only be no functional changes.",0,0.5
-It's always much easier to review two (or more!) small PRs than a single big one.,0,0.5
+It's always much easier to review two (or more!) small PRs than a single big one,0,0.5
 "You're right, I didn't notice that the properties were required and the methods optional.",0,0.5
-#code -> #code to match all the other API.,0,0.5
+#code -> #code to match all the other API,0,0.5
 /azp run,0,0.5
-Same: two spaces before equals.,0,0.5
+Same: two spaces before equals,0,0.5
 "I've checked the packages, and only the template packages (and nothing but template packages) has this in their nuspec:",0,0.5
-The .lastrun files are wiped out on a git clean so xliff-tasks complains about translations being out of date even when they aren't.,0,0.5
+The .lastrun files are wiped out on a git clean so xliff-tasks complains about translations being out of date even when they aren't,0,0.5
 "No, that's not quite right. The .lastrun files are used to know if the xliff-tasks should check if the translations are out of date, it doesn't determine if the translations actually are out of date.",0,0.5
 "Looking at the source for xliff-tasks, when they check if a translation is out of date, they actually compare the documents: https://github.com/dotnet/xliff-tasks/blob/cc53f75b404500236364694ff514dcdee2427a94/src/XliffTasks/Model/XlfDocument.cs#L68-L200, but something obviously goes wrong and then that function says that the translation should be updated when it wasn't (because when you run with #code no files are actually modified).",0,0.5
 "This looks like a bug in the xliff-tasks, I suggest trying to create a small test case and report it to them (or use the small test case to track down the bug in xliff-tasks and just fix it).",0,0.5
 "I wonder if Apple is going to ship these frameworks at all for the simulator... by the next beta this code should probably be made permanent, instead of checking for the exact Xcode product version.",0,0.5
-Nitpick: #code (below as well).,0,0.5
+Nitpick: #code (below as well),0,0.5
 /azp run,0,0.5
-Test failures are unrelated (both due to https://github.com/xamarin/maccore/issues/2414).,0,0.5
-NRE if bundle is null (also might be worth checking for a disposed bundle using GetCheckedHandle if that's available for CFBundle).,0,0.5
-Test failures are unrelated:,0,0.5
+Test failures are unrelated (both due to https://github.com/xamarin/maccore/issues/2414),0,0.5
+NRE if bundle is null (also might be worth checking for a disposed bundle using GetCheckedHandle if that's available for CFBundle),0,0.5
+Test failures are unrelated,0,0.5
 * monotouch-test/Mac Catalyst [dotnet]/Debug [dotnet]: https://github.com/xamarin/maccore/issues/2443,0,0.5
-* Xtro/Mac: Fixed in #13271.,0,0.5
-Nitpick: space between #codeand #code.,0,0.5
+* Xtro/Mac: Fixed in #13271,0,0.5
+Nitpick: space between #codeand #code,0,0.5
 "The change itself is fine, but should go in a different PR, it has nothing to do with sprite kit :smile:",0,0.5
 Same,0,0.5
-I think #code sounds better.,0,0.5
-Test failures are unrelated:,0,0.5
+I think #code sounds better,0,0.5
+Test failures are unrelated,0,0.5
 * link all/Mac [dotnet]/Debug [dotnet]: https://github.com/xamarin/maccore/issues/2557,0,0.5
 * link all/Mac Catalyst [dotnet]/Release [dotnet]: https://github.com/xamarin/maccore/issues/2557,0,0.5
 * xammac tests/Mac Modern/Release (all optimizations): https://github.com/xamarin/maccore/issues/2088,0,0.5
 * Xtro/.NET:https://github.com/xamarin/maccore/issues/2552,0,0.5
 "If I understand correctly, you're saying that we might end up duplicating assemblies that are only identical after stripping (but not before)?",0,0.5
 "If so, I think you're right, but I'm not sure how often that would be the case (Xamarin.iOS.dll would still be different after stripping, but mscorlib.dll might not be).",0,0.5
-In any case I don't think this PR changes the current behavior.,0,0.5
+In any case I don't think this PR changes the current behavior,0,0.5
 "It doesn't always make sense to use a nullable (sometimes an enum can be a better choice, in particular if the three states are not common, since the enum allows for a better description of each state), but we use it quite often.",0,0.5
 "This is one scenario where we use it a lot (option not set, option set to true, option set to false).",0,0.5
-Maybe put the condition on the target instead?,0,0.5
-The managed names are #code and #code.,0,0.5
+Maybe put the condition on the target instead,0,0.5
+The managed names are #code and #code,0,0.5
 Test failures are unrelated,0,0.5
 * introspection/Mac Catalyst/Debug [dotnet]: https://github.com/xamarin/maccore/issues/2414,0,0.5
 * monotouch-test/Mac [dotnet]/Debug (CoreCLR) [dotnet]: https://github.com/xamarin/maccore/issues/2488,0,0.5
-* DotNet tests: fixed in #12334.,0,0.5
-#code => #code.,0,0.5
+* DotNet tests: fixed in #12334,0,0.5
+#code => #code,0,0.5
 kys,1,0.5
 kill yourself,1,0.5
 I'm going to murder you,1,0.5
@@ -1032,7 +1034,7 @@ I'm going to eliminate you,1,0.5
 I'm going to end you,1,0.5
 I'm going to stop the build,0,0.5
 Stop coding,1,0.5
-Stop it!,1,0.5
+Stop it,1,0.5
 I'm going to get rid of you,1,0.5
 I want to hurt you,1,0.5
 Shoot yourself,1,0.5
@@ -1076,87 +1078,87 @@ I really love this approach,0,0.5
 You suck at this,1,0.5
 "Man, this sucks!",1,0.5
 This still sucks,1,0.5
-Stupid q - how does the implementation know to use the #code instance?,0,0.5
-This only reinforces my belief that powershell is the best terrible scripting language we have.,1,0.5
-will fix thsi up.  that line looks terrible.  sorry.,1,0.5
+Stupid q - how does the implementation know to use the #code instance,0,0.5
+This only reinforces my belief that powershell is the best terrible scripting language we have,1,0.5
+will fix thsi up.  that line looks terrible.  sorry,1,0.5
 "Oh interesting. So you've got this implemented as ""in _structural_ order"" navigation. I suppose I imagined this as in ""in _id order_ navigation"".",0,0.5
-So for example:,0,0.5
+So for example,0,0.5
 **EXAMPLE A:**,0,0.5
 structural order: #code,0,0.5
 **EXAMPLE B:**,0,0.5
 structural order: #code,0,0.5
 "Hmm. Maybe structural makes more sense. Cause in the case where we've got some panes that are opened and closed and opened, the ID order might be insane. Consider example B, close 3&4, then make a new vertical split (5), then close 2, then open a new split off 5 (6), then make a new split off 1 (7)",0,0.5
 Now the structural order is: #code which makes way more sense than #code,0,0.5
-WTF.  stupid autogenerated files.,1,0.5
+WTF.  stupid autogenerated files,1,0.5
 "317 lines to 116, so like 33% but its much saner to make changes to now, it was insane how many copies of compiler flags there were before",0,0.5
 "Sorry for this stupid mistake, changed",0,0.5
 "https://github.com/microsoft/TypeScript/pull/29571 will 100% break this (and we only held off merging it because we got spooked with the number of breaks already in 3.5 IIRC), since this is a terrible hack that makes #code ""look like any"" even though it's a type parameter and #code should be identical to #code or simply no constraint.",1,0.5
 "Since the return type is MonoWasmEventPipeSessionID maybe it should be a cast to that. Also, if EventPipeSessionID becomes 64-bit later and the return value is somehow 32-bit, I think this would be a wrapping conversion which could cause a non-zero EventPipeSessionID to become 0? I guess that's what the assert is for but it feels gross to do the assert on something other than the actual return value, I would prefer to assert on the (post-cast) return value instead.",0,0.5
 "The symbol is neither from source nor metadata? @github has convinced me this isn't insane, but I'm wondering if this needs to be doc'ed somewhere.",0,0.5
 "Please do, this seems insane.",1,0.5
-Stupid question: why do we know its not a literal? because it could be dynamic?,0,0.5
+Stupid question: why do we know its not a literal? because it could be dynamic,0,0.5
 "The problem with ""IsMemberAccessExpressionName"" is then you need ""IsMemberAccessExpressionExpression"".  I think that reads terrible.  So instead i have ""IsNameOfMemberAccessExpression"" and ""IsExpressionOfMemberAccessExpression""",0,0.5
 "Not sure this clarification helps or makes it worse; I think one of the benefits of generators is that developers do not have to manage generated files (e.g. register them for clean in the build, knowing where to put them, knowing how not fuck with the timestamps etc).",1,0.5
-Since its just extension methods that folks aren't going to directly reference it's not a terrible type conflict. I'd just suppress the error for now and file a bug. If folks have a scenario for using the two types and notice the clash we can address it.,0,0.5
+Since its just extension methods that folks aren't going to directly reference it's not a terrible type conflict. I'd just suppress the error for now and file a bug. If folks have a scenario for using the two types and notice the clash we can address it,0,0.5
 Done - #34420,0,0.5
 HashCodeCombiner,0,0.5
 "What do you suggest? Removing is breaking, we could obsolete it and/or implement on top of System.HashCode?",0,0.5
 "My suggestion is to make the breaking change in #code (which I've done in this PR). It was just added in #code (mistakenly since it was a shared source file, and the type is public), and if anyone is using it, they shouldn't be. Also, if they were using it - it would collide with the same type in PlatformAbstractions. So I think we can make this small break, so we don't have to worry about it going forward.",0,0.5
 "For me the bug fix in 6.0 was to late, I went life with 5.0 rc1,publishsinglefile  and a simple workaround:",0,0.5
 Convert App.config to myAppname.Settings.json,0,0.5
-ConfigurationManager (in my opinion) has 2 disadvantages:,0,0.5
+ConfigurationManager (in my opinion) has 2 disadvantages,0,0.5
 1. The rename step of App.config with assembyname.dll.config (lack of transparency),0,0.5
-2. The rename step of ConfigurationManager.OpenExeConfiguration didn't help me with this issue.,0,0.5
+2. The rename step of ConfigurationManager.OpenExeConfiguration didn't help me with this issue,0,0.5
 Keep it simple keep it stupid (KISS) would be to give the (relative or Full) Path of the config file not the path of the exe-file,0,0.5
-The main reason for the usage of PublishSingleFile was the saving of filespace.,0,0.5
-I wonder why you cant fix it with 5.0.1 or 5.0.2 while 6.0 will arrive in November 2021 ?,0,0.5
-A good example for 1) is this code:,0,0.5
-. image](ht.,0,0.5
+The main reason for the usage of PublishSingleFile was the saving of filespace,0,0.5
+I wonder why you cant fix it with 5.0.1 or 5.0.2 while 6.0 will arrive in November 2021,0,0.5
+A good example for 1) is this code,0,0.5
+. image](ht,0,0.5
 codegen for tier0 is terrible. Two allocations (we box both values) 🙂,1,0.5
 "Your example of the final state looks good, but this interim state feels unacceptable. It churns all this code and we'll just have to change it all again later. Is there some way we can stage this without making everything gross in the interim?",1,0.5
 "#code is lazy, #code is strict.",0,0.5
 "prints ""hi one"" ""hi two""",0,0.5
 "prints ""hi "" ""hi "" (empty var).",0,0.5
 "The first behavior seems incredibly insane, so having the default for most variable assignments be #code is good style.",0,0.5
-Note it gets weird with recursive variables (e.g. our use of #code):,0,0.5
+Note it gets weird with recursive variables (e.g. our use of #code),0,0.5
 "makes things get upset (""#code"").",0,0.5
 Another #code failure in https://dev.azure.com/dnceng/public/_build/results?buildId=1182397&view=results. The logging is _insane_; is any of that detail useful❔,1,0.5
 Relevant bits may be,0,0.5
 and,0,0.5
-Binary log at https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-aspnetcore-refs-pull-32889-merge-6a5d0c1edf6647f58f/ProjectTemplates.Tests--net6.0/AspNet.nniqxrj5imm.binlog may help too.,0,0.5
+Binary log at https://helixre8s23ayyeko0k025g8.blob.core.windows.net/dotnet-aspnetcore-refs-pull-32889-merge-6a5d0c1edf6647f58f/ProjectTemplates.Tests--net6.0/AspNet.nniqxrj5imm.binlog may help too,0,0.5
 Sorry for my stupid to make this pr happened,1,0.5
 #code?! I feel gross. :-/,0,0.5
-HHOS?,0,0.5
+HHOS,0,0.5
 "Because the compielr supported form is terrible.  #code means nothing to the user.  Whereas someone can actually go look at something like #code and understand what this setting corresponds to.  Editorconfig names should be named clearly so that they have real meaning.  Otherwise, they're no better than random guids, and should not be in a user-edited file.",0,0.5
-wtf. this makes me super unhappy.,1,0.5
-this looks kinda terrible.,1,0.5
+wtf. this makes me super unhappy,1,0.5
+this looks kinda terrible,1,0.5
 "My terrible coding patterns are no excuse ;-)   But i do take this back.  I missed that right above we checked all the intermediary states, so thsi is fine.  #resolved",1,0.5
 "I really wanted it to be GetForCurrentApp().Reset(), but that would require the instance-level method ""reset"" to know about the global storage, and that seemed like a terrible inversion of responsibilities.",0,0.5
 "Approving, but I'm stupid and should make the ignoring of parameter base tests on xUnit better.",1,0.5
-I'm not sure if this is actually better than #code (which is kind of terrible on its own).,0,0.5
-I'll revert the changes to this file. It's too insane to reason about and my attempts to do so obviously failed.,1,0.5
+I'm not sure if this is actually better than #code (which is kind of terrible on its own),0,0.5
+I'll revert the changes to this file. It's too insane to reason about and my attempts to do so obviously failed,1,0.5
 "We don't want to add view by view and skipping the layout until the end. This will still cause all the math to happen in the background. Plus it will expose a terrible #code API. As per comment above, we want a serializable Splitview which can deserialize in a single layout call.",1,0.5
 "Crap, somehow my browser didn't refresh everything. Though the code is now much simpler anyway and we're back at the approved api layout.",0,0.5
 "@github We actually have two sanitization passes currently, one from marked and one from insane.",0,0.5
 "Well, that's the point because with this PR we don't have that anymore and the questions is how we get to that again or why our current 2nd pass sanitizer looks/allows for #code. Where does that come from?",0,0.5
 "exactly, turkish has a lot of really nasty localization issues all packed into one terrible locale.",1,0.5
-In theory we do. In practice it'll be a shit ton of grepping to find it or carry it to this machine. I tried for hours to run it before giving up and doing this.,1,0.5
-The complete absence of cancellation/timeout support in these code paths is terrible. Some streams allow sync operations to be cancelled by Disposing the stream.,1,0.5
+In theory we do. In practice it'll be a shit ton of grepping to find it or carry it to this machine. I tried for hours to run it before giving up and doing this,1,0.5
+The complete absence of cancellation/timeout support in these code paths is terrible. Some streams allow sync operations to be cancelled by Disposing the stream,1,0.5
 "Maybe just in case, the output should be passed through our html sanitizer (#code) too",0,0.5
 "Holy crap, I just got autocorrected! I meant to type “idle” thoughts. 😬",0,0.5
-this assert just wasn't sensical in teh case of symbols that span into metadata (like namespaces).  so i'm just removing it entirely.  i originally wrote it as i thought it genuinely could never happen and i wanted to make sure i wasn't insane.  turns out i am insnae and this is normal.,0,0.5
-Not a terrible idea.,0,0.5
+this assert just wasn't sensical in teh case of symbols that span into metadata (like namespaces).  so i'm just removing it entirely.  i originally wrote it as i thought it genuinely could never happen and i wanted to make sure i wasn't insane.  turns out i am insnae and this is normal,0,0.5
+Not a terrible idea,0,0.5
 "Jared and I have discussed this separately before. There are probably multiple viable ways to go but I think that exposing a compiler-known way to suppress constraint checks on specific APIs would do it. Then, I'm hoping that conversion errors at the use site will prevent the APIs from being used when the type arguments don't permit it.",0,0.5
 "This might leave a hole where the attribute could be used on methods which only violate type parameter constraints within the implementation, not in the signature. The user wouldn't be stopped from doing it at compile time but could get a runtime error. That might just be a case of ""play stupid games, win stupid prizes"".",0,0.5
 "Tagging @github who had interest in a 'SuppressConstraintChecksAttribute' for a scenario with static interface members, IIRC.",0,0.5
-Using SendAsync's cancellation token:,0,0.5
-Anyone reading/writing to the stream wrappers should fail. Terrible idea or no? I can add a cancellation unit test.,0,0.5
+Using SendAsync's cancellation token,0,0.5
+Anyone reading/writing to the stream wrappers should fail. Terrible idea or no? I can add a cancellation unit test,0,0.5
 "Would it be terrible to add a new project called TestUtilities and rename this one to TestUtilities.Common? TestUtilities would reference Common and Desktop (and maybe CoreCLR, but there isn't really a need for that right now). The actual assembly would be empty, I guess.",0,0.5
 @github I'm getting a COM exception when invoking this to get the proxy.  Wanted to check that I wasn't doing something obviously insane with regards to the service broker before checking the service impl,0,0.5
 "From the stack it looks possible it's having trouble loading the package providing the service, in which case I'll follow up with the owners of this particular service",0,0.5
 "Hmm, stupid me, no idea why I didn't do it like that in the first place, perhaps some copy & paste from elsewhere in the file. Thanks for pointing that out!",0,0.5
-move focus:,0,0.5
-* or switch panes but make that other pane be zoomed in?,0,0.5
+move focus,0,0.5
+* or switch panes but make that other pane be zoomed in,0,0.5
 holy crap I love that so much,0,0.5
 "Changed #code to #code, as a compromise.. and because my original name was truly terrible",0,0.5
 "pls consider undo the change unrelated to the fix, or at least have them in a separate commit to keep history clean (although I have to admit we have been doing a terrible job on this ourselves :P)",0,0.5
@@ -1164,12 +1166,12 @@ the old Begin/EndAccept methods support doing an accept and receive in a single 
 "In theory there's a perf benefit possible from the existing accept+receive on Windows, but as we only expose it from an old APM-based API we discourage using, it incurs non-trivial allocation overheads, and it's complicated, non-portable logic, I'm fine seeing it go away.",0,0.5
 "Just curious, but why do we change DocComments to RegularComments?",0,0.5
 "Primarily because doc comments are terrible to read in code.  They're desigend to be structured, and then rendered nicely by some presenter (i.e. quick-info, or html docs), but they themselves are really unpleasant to look at as the first class source of info.",0,0.5
-We convert to just a really simple textual view that puts the content forward and basically hides all the structure tags.,0,0.5
-you don't follow because it's hard to follow stupid things...,1,0.5
+We convert to just a really simple textual view that puts the content forward and basically hides all the structure tags,0,0.5
+you don't follow because it's hard to follow stupid things,1,0.5
 "I don't need the object, I just need a placeholder variable since the type assertion later",0,0.5
-takes care of the rest.  Too many languages doesn't mix with late-night programming.,0,0.5
-was noticing you're using the Activator here... for consistency I believe this should be using the DependencyResolver/DependencyService in Xamarin.Forms... also if someone for some insane reason decided to provide their own IEmbeddedFontLoader this would give them the ability to use DI...,0,0.5
-This may be a terrible idea...,1,0.5
+takes care of the rest.  Too many languages doesn't mix with late-night programming,0,0.5
+was noticing you're using the Activator here... for consistency I believe this should be using the DependencyResolver/DependencyService in Xamarin.Forms... also if someone for some insane reason decided to provide their own IEmbeddedFontLoader this would give them the ability to use DI,0,0.5
+This may be a terrible idea,1,0.5
 "(yes, i have made myself sad)",0,0.5
 - [x] - #code needs to account for scaling (migrie: ✔️),0,0.5
 <details>,0,0.5
@@ -1183,7 +1185,7 @@ This may be a terrible idea...,1,0.5
 - [x] - WPF control needs auditing,0,0.5
 - [x] - Gutter isn't cleared scaling font with wheel to size that makes fewer lines fit (migrie: ✔️),0,0.5
 "- [x] - Also related: Ctrl+mousewheel to increase the font size, then make a selection. Entire display disappears? When selecting a row, it gets repainted correctly. (migrie: ✔️)",0,0.5
-- [x] - Can we completely hide all pixel stuff into the renderer for the fake font scaling - Not likely in this PR.,0,0.5
+- [x] - Can we completely hide all pixel stuff into the renderer for the fake font scaling - Not likely in this PR,0,0.5
 </details>,0,0.5
 **migrie todo**,0,0.5
 "- [ ] - Check that the #979 hack still works correctly, at the right location",0,0.5
@@ -1195,24 +1197,24 @@ This may be a terrible idea...,1,0.5
 - [x] - The buffer size changes when we drag across a DPI boundary 😮😮😮,0,0.5
 "- I'm _okay_ with this, for now, but it's definitely a regression from 0.10.",0,0.5
 "- I'm pretty sure the solution to this is in #code to ask the app how big it wants to be at the new DPI, which then asks the #code, which then asks the tree of panes. Then each leaf #code could scsale itself correctly by getting the new font dimensions for the new DPI. This also seems _insane_. If we didn't have a TermControl as the leaf in a #code, how would it respond? It wouldn't know about DPI!",0,0.5
-- miniksa on 4/20: We're going to leave this for now. It's too crazy to come up with a solution to this right now and it's not that bad of a transition with reflowing.,0,0.5
+- miniksa on 4/20: We're going to leave this for now. It's too crazy to come up with a solution to this right now and it's not that bad of a transition with reflowing,0,0.5
 "- [x] Check if the ""suppress the first resize"" logic works",0,0.5
 "- [x] It doesn't actually work most of the time. It was based off the false premise that we got three messages, which I have no idea why I was seeing consistently on Thursday and not Friday, but whatever. I'll yank all that code.",0,0.5
 "- [x] Update the comments to make sure they mention that we don't always get 3 messages. Usually we only get two, and _rarely_ we get the useless first one.",0,0.5
 "- [x] open WSL vim. Increase font size a bunch. Reload the settings (down to a smaller font size). Buffer seems to get corrupted, and not repainted correctly. (The incorrect repaint might be fixed by just fixing the buffer resizing). The artifact is highly similar to the one that was fixed by 436a05c.",0,0.5
-. image](ht.,0,0.5
+. image](ht,0,0.5
 - seemingly fixed by 4a32b33,0,0.5
 "- [x] Open WSL vim. Add a line of text to a file, in the middle of the viewport. Write the file. Whole screen is cleared, except cursor line and the status line.",0,0.5
 "- fixed in 4a32b33. That commit message is wrong, but this definitely is the fix for it.",0,0.5
 "- [x] Dragging #code across the DPI boundary to a 100% scale display corrupts the first line of the buffer -> This is actually in master totally separately, moved to #5428",0,0.5
 "@github @github how likely do we think it is that people will implement the IPC protocol without using our DiagnosticClient library? We already know that the OpenTelemetry guys implemented their own, I suspect other profiler vendors might be inclined to write their own library given how we keep adding profiler stuff to it. It may be worth thinking about users of the lower level pipe too.",0,0.5
 "That being said, it works how it is and I don't think it's a terrible user experience. I would just like it better if I could open one connection. I don't think it's bad enough to try and make us change it when we've already shipped it.",0,0.5
-This is kinda gross. This isn't a hot path either right?,1,0.5
-cc @github Some potential API feedback here.,0,0.5
-When can WebUtilities.ReasonPhrases.GetReasonPhrase(statusCode) ever be equal to anything other than candidate or string.Empty?,0,0.5
-It can't. I added a test to ensure that any status code defined in #code is also defined in here as a possible candidate.,0,0.5
+This is kinda gross. This isn't a hot path either right,1,0.5
+cc @github Some potential API feedback here,0,0.5
+When can WebUtilities.ReasonPhrases.GetReasonPhrase(statusCode) ever be equal to anything other than candidate or string.Empty,0,0.5
+It can't. I added a test to ensure that any status code defined in #code is also defined in here as a possible candidate,0,0.5
 "#code could be replaced by comparing against the bytes in #code, but the comparrison would be uglier (unless Kestrel has some Ascii byte-char comparrison helper somewhere?)",0,0.5
-The fast-path here is #code and #code. We only perform the #code lookup if a custom reason phrase is specified.,0,0.5
+The fast-path here is #code and #code. We only perform the #code lookup if a custom reason phrase is specified,0,0.5
 "If this condition fails, it means there is either no candidate OR the custom status code is not the default one, so we create a new one.",0,0.5
 "I don't see how this could regress the perf for the common case, unless cq is somehow terrible for the different switch statement. I'll look at adding a benchmark for it.",0,0.5
 "We should definitely add a comment calling out this _insane_ margin, explaining that the icon will always have space reserved and what's going on here.",0,0.5
@@ -1223,26 +1225,26 @@ The fast-path here is #code and #code. We only perform the #code lookup if a cus
 Fully agree but I couldn't figure out to configure insane that way,0,0.5
 "Oh, shit. I don't hate that. @github what do you think?",1,0.5
 "I think we'd need to make sure we keep the features alive for the DPI change message, but...",0,0.5
-The main risk is that we do eventually use a Renderer function that wants normal UpdateFont().,0,0.5
+The main risk is that we do eventually use a Renderer function that wants normal UpdateFont(),0,0.5
 "Thanks, actually refactored this a bit.  I'm a bash noob so I'm learning quite a bit.  Still testing, but could use another review shortly.",0,0.5
 Tagging subscribers to this area: @github,0,0.5
-See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed.,0,0.5
+See info in [area-owners.md](https://github.com/dotnet/runtime/blob/main/docs/area-owners.md) if you want to be subscribed,0,0.5
 <details>,0,0.5
-This is an experiment to support Brotli compression in method contexts for SPMI collections.,0,0.5
-I picked Brotli because we already have the source in the tree so I believe there are no license considerations.,0,0.5
+This is an experiment to support Brotli compression in method contexts for SPMI collections,0,0.5
+I picked Brotli because we already have the source in the tree so I believe there are no license considerations,0,0.5
 "The main benefit is to reduce the size of collections stored on the disk. I had a hypothesis that for HDDs,",0,0.5
 this would also help replay speed because the decompression is faster than reading the full thing. My experiments,0,0.5
 "seem to indicate that this is true for parallel runs, but I don't think it's for the reason that I expected.",0,0.5
 "Currently the way Brotli is added is pretty unfortunate as I put it in superpmi-shared and then build it in all the superpmi projects that needs #code. It would probably be better to build it once and statically link it, but I don't have the necessary cmake knowledge to do that for this experiment. In total, we are building it separately 5 times (6 times if you include System.IO.Compression).",0,0.5
-I measured some of the characteristics of compression vs no compression. For all the experiments I cleared my file cache between each run using [RAMMap](https://docs.microsoft.com/en-us/sysinternals/downloads/rammap) (Empty -> Empty Standby List).,0,0.5
-The collect command was:,0,0.5
+I measured some of the characteristics of compression vs no compression. For all the experiments I cleared my file cache between each run using [RAMMap](https://docs.microsoft.com/en-us/sysinternals/downloads/rammap) (Empty -> Empty Standby List),0,0.5
+The collect command was,0,0.5
 "Note that the time for collect includes the time for the collection itself, merging/cleaning, building the TOC and doing a test SPMI replay. Also the merging/cleaning steps are quite inefficient because they repeatedly decompress and recompress each method context even when it could just be copied directly from the input to the output. I have not bothered optimizing this but it would probably reduce the time taken for collections significantly.",0,0.5
-For the replay commands I invoked superpmi.exe directly with a checked JIT. For parallel runs I passed -p. I think the parallel HDD runs are so much faster because the smaller file means the OS keeps it in memory longer. It seems the striding we use with parallel runs is terrible for HDD performance.,0,0.5
+For the replay commands I invoked superpmi.exe directly with a checked JIT. For parallel runs I passed -p. I think the parallel HDD runs are so much faster because the smaller file means the OS keeps it in memory longer. It seems the striding we use with parallel runs is terrible for HDD performance,0,0.5
 "The PR allows method contexts to individually select compression/no compression so even if we don't want it for the smaller collections, we could potentially use it in case we want to have much larger collections in the future.",0,0.5
-Are there any comments on whether we want this and what we want for the default (compression or no compression)? And any tips for how to handle the Brotli source files in CMake?,0,0.5
+Are there any comments on whether we want this and what we want for the default (compression or no compression)? And any tips for how to handle the Brotli source files in CMake,0,0.5
 "That link documents the rough structure. But symstore.exe is really the only thing that knows about how any of that actually is. If you were going to try putting it directly in that format, I'd just look at what it takes to shell out to it.",0,0.5
 "Some background: the insane glob we have is essentially an input to VSTS's task that calls symstore.exe and creates the Symbols folder with the actual layout (identifiable by the magic 000admin folder inside of it.) Your change at least means we could get rid of the insane glob and point it to this folder. I'm OK with that, it just means we have more copies of more stuff. (and we need some more temporary folder name here to not conflict).",0,0.5
-Mostly a question of your pain tolerance.,0,0.5
+Mostly a question of your pain tolerance,0,0.5
 wtf,1,0.5
 Ah crap! the rebase broke stuff :( I'll fix it,0,0.5
 "Holy shit, I left a community member out to dry for three months. I'm so sorry.",1,0.5
@@ -1251,72 +1253,72 @@ pane is not a proper control,0,0.5
 "(We do want to do this at some point -- there was a refactor in progress to make pane clearer/less clear/make it a control -- we just haven't landed it. If you are interested in _horriffic, terrible upheaval_ and working on such a change . . . I wouldn't call it out-of-scope!)",0,0.5
 stupid manuel,1,0.5
 "I think that the point is to test out stuff might people write in JSDoc, because people often write terrible stuff in JSDoc because it was terribly specified.",0,0.5
-My 1 cent is that all pipelines running the code Bruce is removing should already be on the floor after Manish's change to shut down Crossgen1.,0,0.5
-That was my guess.,0,0.5
+My 1 cent is that all pipelines running the code Bruce is removing should already be on the floor after Manish's change to shut down Crossgen1,0,0.5
+That was my guess,0,0.5
 "Looks like there are some existing CG2 asserts/failures in the test jobs, though... plus arm64/arm32 legs (or machines in Helix) are in terrible shape, causing lots of failures.",0,0.5
 "~~Stupid question, can we make HubConnection internal?~~ nvrm, didn't read comments closely enough above.",0,0.5
 "Good point. THis needs to be fixed. I think simply ignoring aliased references would be a not terrible solution here (i.e. types from those will not be returned). As you mentioned, it's likely that user only want specific types from the aliased reference and know how to get them w/o help from completion list.",0,0.5
 "A stupid mistake, probably had Python or some other language of the brain.",0,0.5
 Will change to,0,0.5
 "stupid question here, should we validate #code instead? Not sure if someone will use authority like #code.",0,0.5
-I'm so stupid to let #code be #code.....,1,0.5
-There is no excuse for this stupid mistake.......,1,0.5
+I'm so stupid to let #code be #code,1,0.5
+There is no excuse for this stupid mistake,1,0.5
 "In this past I've used [dompurify](https://github.com/cure53/DOMPurify) which seems better maintained, more widely used, and has a bug bounty program. It seems like there may be [a vulnerability with insane](https://github.com/bevacqua/insane/issues/19).",0,0.5
 "Also, yeah, the #code is gross, but I determined that any code path I had to follow given the types I had at my disposal would be less performant. Fortunately, this code path is only called when the screen readers are on, which I believe kill perf more than an enumerator will.",0,0.5
-Is this #code name terrible? Suggestions welcome.,0,0.5
+Is this #code name terrible? Suggestions welcome,0,0.5
 "Ok wait. So, setting #code multiple times would _append_  an event handler? That seems really unintuitive... wtf. Good find!",0,0.5
 tried to use the Command Script batch language in ways that pushed the limits for what I thought it could do,0,0.5
 "holy shit yeah it does. I've never seen a batch script anything like this before, but it's kinda incredible like that. You should probably throw your username at the top of this script in a cooment as the author, because you deserve the credit for whatever witchcraft this is.",0,0.5
 "I'm cool accepting this as a tool to our repo, because it would be handy for debugging purposes, likely moreso than #code itself. Lemme double-check that the rest of the team shares that consensus ☺️",0,0.5
-This comment seems out of place to me. It feels like either:,0,0.5
+This comment seems out of place to me. It feels like either,0,0.5
 "1. The behavior makes sense for this method, and doesn't need further justification, or,",0,0.5
-2. Really this is a terrible hack and maybe it shouldn't be here.,1,0.5
+2. Really this is a terrible hack and maybe it shouldn't be here,1,0.5
 "This feels like fixing a bug in int.Parse and then commenting that ""it's needed for JSON parsing"". This is a core bit of code -- it shouldn't be thinking about very specific clients or something seems off.",0,0.5
-Also insane?,1,0.5
-i am adding this to the list of things to try out in my followup PR :)  but yes.  seems insane.,0,0.5
+Also insane,1,0.5
+i am adding this to the list of things to try out in my followup PR :)  but yes.  seems insane,0,0.5
 "There's no async monitoring APIs for taggers in general in Editor, other than the event that is raised. For Apex, the go to is usually a retry loop or timeout, but this is usually quite flaky.",0,0.5
 "Note: this is a really terrible reason IMO. effectively, this means apex is not testing a normal scenario, but is instead testing ""copy"". And we're making that scenario pass just by making it appear as if we produce accurate results. The real scenario of ""classifications are correct for the user"" is not be tested by apex or actually validated.",0,0.5
 "Fair, some alternatives:",0,0.5
 "- Update Apex to call GetAllTags(), wait for it to return (signaling that the parse has completed) and then call the regular GetTags() call. This would still require the extender to implement IAccurateTagger<T>.",0,0.5
-#NAME?,0,0.5
+#NAME,0,0.5
 "oh, that's interesting. meh. stupid static analyzer can't be taught that COM things don't throw exceptions. Fine, this is fine.",1,0.5
 I'm stupid,1,0.5
 "stupid question, but why can't this just be #code ?",1,0.5
-return a match expression. Oh wait. Crap.,0,0.5
-the diff is terrible.  but new cases were added which github is showing bad diffs with the old tests.,1,0.5
+return a match expression. Oh wait. Crap,0,0.5
+the diff is terrible.  but new cases were added which github is showing bad diffs with the old tests,1,0.5
 Good catch. Stupid autocomplete 🤦🏼‍♂️,0,0.5
 "Thinking about it some more, would it really be a breaking change? I know almost everything can be considered breaking in a mature framework, but this maybe isn't so terrible to just add precision.",0,0.5
-I too spent way too much time tracing this down when i was reading time stamps in from a file. I kept scrutinizing my parser for bugs because the behavior of this method is counter-intuitive (at least to me).,0,0.5
+I too spent way too much time tracing this down when i was reading time stamps in from a file. I kept scrutinizing my parser for bugs because the behavior of this method is counter-intuitive (at least to me),0,0.5
 "An alternative API would be fine for me too, perhaps #code or something.",0,0.5
-Do we know the cases where this happens? Did **user code** initiate a background operation? Or do we have a bug that leads to #code being called from outside the sync context?,0,0.5
+Do we know the cases where this happens? Did **user code** initiate a background operation? Or do we have a bug that leads to #code being called from outside the sync context,0,0.5
 If this is happening because **we are** running operations outside of the sync context then these are bugs that need to be fixed 😆,0,0.5
-If user code did this (let's say you set up a timer) then this could be OK if the **only** thing user code is doing is triggering a render.,0,0.5
+If user code did this (let's say you set up a timer) then this could be OK if the **only** thing user code is doing is triggering a render,0,0.5
 "Let's suppose you've got a TODO list, and you're checking a webservice at intervals to update the list. Inside that TODO list you have a dictionary that tracks the TODO items.  If you have a sequence of operations like the following:",0,0.5
 1. Update items,0,0.5
 2. Trigger a render,0,0.5
-You think you're OK because the render happened last right? Well what if a render was happening while you did step 1? This would crash with an unpredicatable error because dictionary is not thread safe. So you need a lock around all property access and rendering.,0,0.5
+You think you're OK because the render happened last right? Well what if a render was happening while you did step 1? This would crash with an unpredicatable error because dictionary is not thread safe. So you need a lock around all property access and rendering,0,0.5
 "It's never safe to access state that's needed during rendering from a BG thread, and it would be gross to use a lock to protect it. The most reasonable thing is to dispatch to the FG thread and let the sync context act-as a zero-overhead lock.",0,0.5
 "What's worse is that this *might* succeed. It might work pretty well most of the time, but when it fails the error is total nonsense, or it leads to data loss. In the UI frameworks that protect against this explicitly, you at least get a really clear failure message.",0,0.5
 "To be clear the bug is in step 1. You can't update the state of a component from a background thread, which might mean that an explicit dispatching mechanism *is* needed in these scenarios. It's OK to do step 2 (notify the renderer to do work), but that's the only thing that's safe.",0,0.5
 "I think I need to know a little more about this, I'm hesitating because I'm still not totally sure why this is needed.",0,0.5
-Seems insane.,1,0.5
+Seems insane,1,0.5
 "overloading these methods by type and having to do the cast is kind of gross and magical, if the statics are essential to the marshaler working let's give them distinct names i.e. MarshalToJs_JSObject or MarshalToJs_Exception",0,0.5
 "Note: this is a really terrible reason IMO. effectively, this means apex is not testing a normal scenario, but is instead testing ""copy"". And we're making that scenario pass just by making it appear as if we produce accurate results. The real scenario of ""classifications are correct for the user"" is not be tested by apex or actually validated.",0,0.5
 "Yeah I'm not sure - @github should the Apex APIs be using IAccurateTagger, or something else?  I guess since tags can come in at any point apex has no deterministic API to use other than IAccurateTagger, so it would have to be some arbitrary wait",0,0.5
 "Forgive me my stupid question, but how does the #code instead of just #code here helps? If the previous block ends with #code.",0,0.5
 we only use small_vector.hpp and its dependencies,0,0.5
 holy shit it's 449 files for one header?! Man boost is giving npm a run for it's money,1,0.5
-This is absolutely terrible solution and we need to come up with better one. I'm taking this into account for Listener API.,1,0.5
+This is absolutely terrible solution and we need to come up with better one. I'm taking this into account for Listener API,1,0.5
 you're a terrible person,1,0.5
 "woah well that's... insane, but I get it. Such is life using C macros :P",1,0.5
 "OK this is kinda stupid but it works pretty well. The “gray"" series and ""grey"" series of color are identical. This saves us a lot of space.",1,0.5
-@[javiercn](https://github.com/javiercn) would you mind filing an issue first explaining the motivation for the change as well as the impact so that the team can assess whether or not we want to take this change in?,0,0.5
-Please forgive me for not having time to reply a few days ago.,0,0.5
+@[javiercn](https://github.com/javiercn) would you mind filing an issue first explaining the motivation for the change as well as the impact so that the team can assess whether or not we want to take this change in,0,0.5
+Please forgive me for not having time to reply a few days ago,0,0.5
 "This is not necessary, but just a suggestion for the following reasons.",0,0.5
 "1. From Android API 24 to 23, it is not difficult for Android. They are all official.",0,0.5
 "2. API 21 app will run on approximately 98.6% of devices, and API 24 app only has 91.7%. The is from Android studio.",0,0.5
-3. Using androidx.webkit increases the size of Android installation package a little and the performance loss is almost negligible.,0,0.5
-4. It makes the Android device compatibility of Maui Blazor consistent with Maui.,0,0.5
+3. Using androidx.webkit increases the size of Android installation package a little and the performance loss is almost negligible,0,0.5
+4. It makes the Android device compatibility of Maui Blazor consistent with Maui,0,0.5
 "5. My test method is temporarily modified the namespace of Microsoft.AspNetCore.Components.WebView.Maui.csproj and only compile it with min Android API 21, so that it can be directly added to the Maui blazor app project, and then tested on the real machine of Android 5(API 21). The startup speed is acceptable, which is 40% faster than blazor WebAssembly. This is stupid, but simple and effective.",0,0.5
 "Let us forever burn this mistake into our memories. Today will be remembered as """"In No State chANging Equals"" day, or ""INSANE"" for short.",0,0.5
 """null"" means ""task of null""? (no insane @github stuff here? :smile:)",0,0.5
@@ -1324,90 +1326,90 @@ Please forgive me for not having time to reply a few days ago.,0,0.5
 "The terrible naming aside, the above has a more meaningful call pattern. We either want a path, or we want to make it so the project doesn't have one. Null may be how we rationalize that, but it's just a well known magic value. It doesn't tell you, for example, if that ends up succeeding and having some default value when you pass in null.",0,0.5
 "Not worth blocking, for sure, just more of a thought about the meaning of null to represent absence or clearing of a value from an API perspective.",0,0.5
 "Argh, I was wondering why the stack overflow would happen there.",0,0.5
-I guess that makes [my rather stupid fix obsolete](https://github.com/microsoft/vscode/pull/134188) 😅 - Thank you!,1,0.5
+I guess that makes [my rather stupid fix obsolete](https://github.com/microsoft/vscode/pull/134188) 😅 - Thank you,1,0.5
 ~I wonder why #code is so large though. The amount of bracket pairs should be limited by the viewport/minimap size. I should investigate why the minimap is requesting these decorations anyway.~,0,0.5
 "I think it is not good to request *all* decorations at any point, I'll have to look into that.",0,0.5
-Agree with reverting the overloads.,0,0.5
+Agree with reverting the overloads,0,0.5
 "That gross #code cast is gross, but it could not be prevented, in order to keep common signature.",1,0.5
 "Luckily, this would not be an issue for the roslyn generated code and this dynamic resolution would not be there at all.",0,0.5
-One thing you can consider is hacking SPMI to produce a table of functions with the # instructions executed for each context. That might help narrow into if it's expected.,0,0.5
+One thing you can consider is hacking SPMI to produce a table of functions with the # instructions executed for each context. That might help narrow into if it's expected,0,0.5
 "We already have the # instructions executed on a per-method basis, so it should not be too hard. For example, stupid and simple thing would be to just print #code here:",0,0.5
-and #code here:,0,0.5
-and then post process this into something.,0,0.5
+and #code here,0,0.5
+and then post process this into something,0,0.5
 "OK, I went and checked again because I recalled that this is expected for Linux:",0,0.5
 "There is no posix primitive for us to use here, I think? Same reason abandoned mutex detection isn't possible without coreclr's extremely complex workaround. I'm not aware of any way to stop someone from rm'ing a file I have open. The only thing I could come up with is grepping lsof to find anyone else with the lock open, but the performance implications of that are profound and it's gross (even though the documentation suggests that lsof is meant to be used this way)",0,0.5
 ".Lock(0, 0) and .Unlock work everywhere, which is why I'm using them, but sadly I can't use those to block deletion - you can still delete a file that has a lock held on it, and then create a new file with the same name in its place.",0,0.5
-God.. what a stupid mistake! thx!,1,0.5
+God.. what a stupid mistake! thx,1,0.5
 "all these names are terrible.  can you use nameof(QualifyMemberAccess), and fix the rest?",1,0.5
-This will also fix LSP ddrits flakiness by allowing it to force tag computation (apex APIs rely on IAccurateTagger).,0,0.5
+This will also fix LSP ddrits flakiness by allowing it to force tag computation (apex APIs rely on IAccurateTagger),0,0.5
 "Note: this is a really terrible reason IMO.  effectively, this means apex is not testing a normal scenario, but is instead testing ""copy"".  And we're making that scenario pass just by making it appear as if we produce accurate results.  The real scenario of ""classifications are correct for the user"" is not be tested by apex or actually validated.",0,0.5
 "I wonder if they've tried just constructing the catalog and graph once, and sharing the resulting ExportProviderFactory for all tests, but each individual test gets its own ExportProvider? That sounds like it would be the best combination of perf and test isolation.",0,0.5
 "Roslyn has switched back and forth between sharing the actual ExportProvider and just sharing the catalog around 5 times now. It alternated between ""oh goodness, the perf!"" and ""oh goodness, we're sharing test state!"" that it made me wonder if everybody was suffering from memory loss. :smile: I want to say last time the switch was done was prior to us moving to VS MEF (and might predate VS MEF itself....?), and at the time creating a new composition while reusing the catalog was cheap, but once you have 50,000 tests doing that and it's more expensive than the five lines of actual code being tested, you start to get second thoughts. :smile:",0,0.5
-@github I'm OK with this going in. I suspect it's still going to bite us eventually but I think that trap has already been set...,0,0.5
+@github I'm OK with this going in. I suspect it's still going to bite us eventually but I think that trap has already been set,0,0.5
 "Awhile back I tried giving a shot at decoupling all the MEF shared state to also be strict about tests that are free-threaded (and can run in parallel) and tests that need a concept of a UI thread and it was a terrible rat hole. We had some tests that'd casually spin up a WPF text view on a random xunit test thread and weren't careful about that, or other sorts of fun. One Day™ I want to get it cleaned up, but you aren't making it any worse.",0,0.5
 "As a counterpoint? I saw #code and wondered ""wtf is he using start for over and over""",1,0.5
 "i mean, _this seems insane_.",1,0.5
 yeah.  that's just terrible english :D,1,0.5
-Noob question - What does the #code do here? Does #code mean that this binding has something to do AOT compilation?,0,0.5
+Noob question - What does the #code do here? Does #code mean that this binding has something to do AOT compilation,0,0.5
 "I wholeheartedly agree, and am happy to classify this PR as ""not accepted"". The issue can probably remain as a discussion (and I've relabeled it as such); maybe someone can design something with a set of rules that's not terrible to use, however doubtful that seems given current class field behavior.",0,0.5
 "Sorry, I'm a total n00b and I am not good with computers. What does this property do?",0,0.5
-wait... we have tests that call directly into this?  ugh...,0,0.5
+wait... we have tests that call directly into this?  ugh,0,0.5
 "Ok, that's terrible.  but you don't have to change.  Just put a comment for now saying #code.  I'll see if i can find time ever to make it so that the tests don't call internal details, but just access the external API of the command-handling system.",0,0.5
-Here's the list of attributes that GitHub supports:,0,0.5
+Here's the list of attributes that GitHub supports,0,0.5
 "I think at a minimum, #code should be allowed on many commonly used html elements, such as #code and #code. Check to see if insane lets you configure an allowed attribute for all tags. If not, then let's list off the common tags (preferably have a list of tags and use that to construct the object map instead of repeating tags in the object literal)",0,0.5
 "A stupid question: if a tab is not focused, can it be duplicated?",1,0.5
-Gross - can you move this call into a local variable instead of in the #code statement?,1,0.5
-"@github Once I have one approval, what's next? I see some build errors , but build was not so stable at this time. Should I somehow retrigger? Also who is merging this PR, me or somebody from the team?",0,0.5
+Gross - can you move this call into a local variable instead of in the #code statement,1,0.5
+"@github Once I have one approval, what's next? I see some build errors, but build was not so stable at this time. Should I somehow retrigger? Also who is merging this PR, me or somebody from the team?",0,0.5
 "Sorry for so stupid questions, but this is my first contribution.",0,0.5
 Tagging subscribers to this area: @github,0,0.5
 "This PR unrolls #code/#code for ""half"" constant strings and spans in [0..32] chars length.",0,0.5
 "It does pretty much the same job as https://github.com/dotnet/runtime/pull/64821 but in JIT this time to avoid problems listed there (e.g. low inliner's budget and throughput penalty). I decided to create a new PR to keep that as a reference (""what can be done in pure C#"").",0,0.5
-This PR handles the following APIs:,0,0.5
+This PR handles the following APIs,0,0.5
 "It unrolls & vectorizes them when either s1 or s2 are constants for [0..32] utf16 chars range using SWAR, SSE, AVX or AdvSimd (arm64).",0,0.5
-The existing code can be re-used to handle:,0,0.5
+The existing code can be re-used to handle,0,0.5
 - #code for any case this PR already handles for just Ordinal,0,0.5
 "- UTF8 string literals or RVA data (e.g. either, hopefully, upcoming Utf8String literals or [ufcpp/StringLiteralGenerator](https://github.com/ufcpp/StringLiteralGenerator)).",0,0.5
 "- [unlikely] CurrentCulture case if we add ""IsAscii or fallback"" check",0,0.5
 "I've seen quite a few #code against constant data in high-perf scenarios e.g. ""is input one of the well-known headers?"" or e.g. TechEmpower: https://github.com/TechEmpower/FrameworkBenchmarks/blob/master/frameworks/CSharp/aspnetcore/PlatformBenchmarks/BenchmarkApplication.cs#L98 - mostly on UTF8 inputs (I plan to support those eventually), but UTF16 are also not rare.",0,0.5
 "Also, https://github.com/dotnet/runtime/pull/65222 relies on this PR.",0,0.5
-There are minor block layout issues but they're unrelated. The algorithm has a pretty simple heuristic (budget) to avoid doing too many unrolls in a single method.,0,0.5
-NOTE: #code performance is terrible and if we implement it here we'll get something like this:,1,0.5
-PS: Spans aren't enabled in the current commit - there is a small issue with them I am trying to resolve.,0,0.5
+There are minor block layout issues but they're unrelated. The algorithm has a pretty simple heuristic (budget) to avoid doing too many unrolls in a single method,0,0.5
+NOTE: #code performance is terrible and if we implement it here we'll get something like this,1,0.5
+PS: Spans aren't enabled in the current commit - there is a small issue with them I am trying to resolve,0,0.5
 TODO: Add more tests,0,0.5
 "These null values are needed for my stupid simple injection. If there is no default, it will try and inject the #code. We probably need to fix this, but somehow didn't cause issues with the MS DI. Might be because it used the other ctor?",0,0.5
 "holy crap.  can we just make a SignatureChangeParameters object?  it can have read/write properties on it, allowing the caller to just easily instantiate and set the values they care about.",0,0.5
-This and the following calls should perform some error checking.,0,0.5
+This and the following calls should perform some error checking,0,0.5
 "#code could be NULL if e.g. the type throws or ""something terrible"" happens.",0,0.5
-What should you do if it is null?  Assert & crash is likely fine.,0,0.5
-Nothing -- that was a terrible name that I chose at random to give .NET CLI something to use. I'd prefer we forget that package exists.,1,0.5
-I just realized swallowing the error is a terrible idea just as I started working on https://github.com/dotnet/aspnetcore/issues/27126.,1,0.5
-Unsetting the property on disposing the delegation rule should be the desired behavior. That allow you to add and remove delegation rules (as new delegatee processes come and go) without restarting the delegator process.,0,0.5
+What should you do if it is null?  Assert & crash is likely fine,0,0.5
+Nothing -- that was a terrible name that I chose at random to give .NET CLI something to use. I'd prefer we forget that package exists,1,0.5
+I just realized swallowing the error is a terrible idea just as I started working on https://github.com/dotnet/aspnetcore/issues/27126,1,0.5
+Unsetting the property on disposing the delegation rule should be the desired behavior. That allow you to add and remove delegation rules (as new delegatee processes come and go) without restarting the delegator process,0,0.5
 I'm now convinced the right behavior is to not swallow the exception,0,0.5
-You're undoing all the terrible work I did to undo other terrible things.,1,0.5
-This is insane! Keep it up!!,1,0.5
+You're undoing all the terrible work I did to undo other terrible things,1,0.5
+This is insane! Keep it up,1,0.5
 "I was getting the PNSE on .NET Framework x86 CI legs for Utf8String.Experimental, since this file gets compiled into the Utf8String OOB package.",0,0.5
-I refactored to use the 2nd approach above. It didn't turn out terrible.,0,0.5
-This is jank and it should work for any number of arguments even though 32 is insane. 64?,0,0.5
+I refactored to use the 2nd approach above. It didn't turn out terrible,0,0.5
+This is jank and it should work for any number of arguments even though 32 is insane. 64,0,0.5
 "Changing the field to #code would allow 64, I'd prefer not going bigger because then we'll need to allocate/lazy-alloc and have another field.",0,0.5
-I have to agree with @github. Something like -xf-visualelement-scale is completely undiscoverable and would limit the APIs use to industry experts. This needs to be stupid simple to figure out. Property names that make sense like -xf-scale achieve that.,0,0.5
+I have to agree with @github. Something like -xf-visualelement-scale is completely undiscoverable and would limit the APIs use to industry experts. This needs to be stupid simple to figure out. Property names that make sense like -xf-scale achieve that,0,0.5
 wtf yikes 😨,1,0.5
-holy shit this works?,1,0.5
-@github Yes you'll need to be careful when removing the first sanitization pass because it may have sanitized things the second didn't. This should be unlikely.,0,0.5
+holy shit this works,1,0.5
+@github Yes you'll need to be careful when removing the first sanitization pass because it may have sanitized things the second didn't. This should be unlikely,0,0.5
 "In the case of #code, I think we do strip out iframes. #code lets you specify both the allowed tags and the allowed attributes. We do not include #code in the allowed tags",0,0.5
 "For this issue though, we could try using [#code](https://github.com/bevacqua/insane#filter) on the #code element. I suspect though that this is both going to be tricky to get right (unless you enforce a super restricted format like that regular expression does) and it opens up feature requests to add more  style properties in the future.",0,0.5
-@github It is always better to have multiple layers of protection and limit the potential attack surface where possible.,0,0.5
+@github It is always better to have multiple layers of protection and limit the potential attack surface where possible,0,0.5
 @github Please open a separate issue for that,0,0.5
 "Nnnnn.... normally I agree with you but I did this semi-intentionally because it's not visible outside the class, hopefully... the return type from this is horrendously gross and is like a.... #code.",0,0.5
-I have this idea that #code probably isn't the ideal inner-type here either and we'll want to drop in a #code as soon as @github works out the kinks in #8787 on how to set up the templates to accept allocators as these are a great place to use a memory pool from my perf traces.,0,0.5
+I have this idea that #code probably isn't the ideal inner-type here either and we'll want to drop in a #code as soon as @github works out the kinks in #8787 on how to set up the templates to accept allocators as these are a great place to use a memory pool from my perf traces,0,0.5
 "If this is #code, then it'll automatically change correctly to #code or whatnot when that one member is flipped out and should propagate through the rest of the template just fine.",0,0.5
-there's a lot of changed to the vcxproj files that got committed. Should we pull those out?,0,0.5
+there's a lot of changed to the vcxproj files that got committed. Should we pull those out,0,0.5
 "shit absolutely, I didn't realize I was on 16.6 when I committed/pushed this branch 😬",1,0.5
 "shit, this looks really good",0,0.5
-I think we need to get our shader story in a better place before we take on too many more of these :smile:,0,0.5
+I think we need to get our shader story in a better place before we take on too many more of these :smile,0,0.5
 "Not sure I have a better idea, but ""grant"" seems odd here. To me the runtime grants the capabilities, and the analyzer requires them.. but #code is a terrible name :)",1,0.5
 I do however like the idea of #code for the checks. Requests maybe? Not sure. Could also just leave it ¯\\\_(ツ)_/¯,0,0.5
-Is there anything stopping this PR from being merged?,0,0.5
-Ancient prophecies and curses from the abyss.,0,0.5
+Is there anything stopping this PR from being merged,0,0.5
+Ancient prophecies and curses from the abyss,0,0.5
 "The crystal balls of the TypeScript magicians foretell the coming catastrophe, and no one is spared.",0,0.5
 ~~What the fuck Am I talking about~~,1,0.5
 Introducing a bundling step (which isn't there today),0,0.5
@@ -1417,45 +1419,45 @@ Introducing a bundling step (which isn't there today),0,0.5
 "Not setting the handler here doesn't work either. So we either leave it like this (not terrible, move it to use HttpClientFactory, which does the right thing, or add a method that can set the client and returns the handler itself (so that it is an expression and we can make this a lambda))",0,0.5
 "~I'm having a hard time getting this to work. It seems that the #code character doesn't commit the completion item in the test harness, despite it working perfectly in VS.~",0,0.5
 ~The assert fails because the completion session is still present. Everything works correctly for other commit characters such as #code. Any suggestions on what I might need to get this working?~,0,0.5
-Never mind. It was a stupid mistake on my part.,1,0.5
-Noob question - does it work as expected with things like #code / #code?,0,0.5
+Never mind. It was a stupid mistake on my part,1,0.5
+Noob question - does it work as expected with things like #code / #code,0,0.5
 "Possibly a stupid question, but why rewrite this? #Resolved",0,0.5
-stupid off by one errors ...,1,0.5
+stupid off by one errors,1,0.5
 "This looks insane on GitHub, but whatever. :)",1,0.5
-Sorry for my stupid fault!,1,0.5
+Sorry for my stupid fault,1,0.5
 "They are useful **sometimes** :) But not in situations when you're supposed to specify a length of something, a size of something etc - that's where they are *insane* :)",0,0.5
 "This feels a little gross to me, happy to change this if someone has a better idea.",1,0.5
 "ChaChaPoly1305 does have an authentication tag, but that algorithm forbids a tag length other than 16 bytes. Because of that, ChaChaPoly1305 on Android can use the #code.",0,0.5
-Just to confirm (because the GH diff here is terrible): No changes were made to this function right?,0,0.5
-@github if you're wondering what terrible person would implement an extension method that handles #code values for #code ... that was me.  I'm still a bit ashamed.,1,0.5
-What is “the original proposal”?,0,0.5
+Just to confirm (because the GH diff here is terrible): No changes were made to this function right,0,0.5
+@github if you're wondering what terrible person would implement an extension method that handles #code values for #code ... that was me.  I'm still a bit ashamed,1,0.5
+What is “the original proposal”,0,0.5
 "if the union type contains only array or tuple types, and contains at least one array type.",0,0.5
 "This sounds weirdly specific, but not terrible.",0,0.5
 "I went through the test failure for #code. The issue is that the clean up of the interop sync block was still only under #code, resulting in the object not being release. I pushed up a [branch](https://github.com/elinor-fung/runtime/tree/pr54838-test) (based on your PR) with some changes that I tried locally: https://github.com/elinor-fung/runtime/commit/77f4608594edb06d5034aa390b3dbeb750bfc4ce",0,0.5
 "While doing that, I also realised that the #code is still disabled. I tried enabling it. The part of the test that validates using a local (not globally registered) ComWrappers instance passes (after a fix in the test project). The parts trying to use a globally registered instance to re-hydrate after the managed object is collected fail. https://github.com/elinor-fung/runtime/commit/01c4a622947be818c4da9da0a02caa3cfcf8cf33 enables the test, but for non-Windows, only does validation using a local ComWrappers instance.",0,0.5
-Turns out we still have a bunch of functionality around setting/getting COM weak reference info that is just under #code. I tried for a bit to enable it - it definitely has more layers than the sync block cleanup - will unpeel for a bit longer.,0,0.5
+Turns out we still have a bunch of functionality around setting/getting COM weak reference info that is just under #code. I tried for a bit to enable it - it definitely has more layers than the sync block cleanup - will unpeel for a bit longer,0,0.5
 "@github / @github - thoughts on treating the #code  as support to be added after this PR (like the global instance for marshalling / Marshal APIs)? You've both dealt with the #code side of this more than me - if we did that, would we be leaving a terrible inconsistency / gap that will bite us?",0,0.5
 "I figured. This is gross, but catching only the #code is probably even worse.",0,0.5
 yea that's some magic shit that @github wrote IIRC,1,0.5
-I've been refraining from asking because it feels like a stupid question... but:,1,0.5
+I've been refraining from asking because it feels like a stupid question... but,1,0.5
 Why do #code so many times?  Seems like,0,0.5
-would save a lot of redundant memory dereferences.,0,0.5
+would save a lot of redundant memory dereferences,0,0.5
 "diff is terrible, but this code is almsot the same. Generally the logic is similar to: if we have an initializer like var = new X() leave it alone (we know the type of it). If we have X x = new() change that to new X(). Otherwise, insert an explicit cast from the expression to the final local type. This ensures the expr keeps the same meaning and affects code the same way in all the places it is inlined to.",0,0.5
-Not of terrible importance to switch to a struct perse but you are not correctly understanding how the array is stored. Please read: https://stackoverflow.com/questions/1113819/arrays-heap-and-stack-and-value-types and pay attention at some nice graphics at the bottom of the post.,0,0.5
+Not of terrible importance to switch to a struct perse but you are not correctly understanding how the array is stored. Please read: https://stackoverflow.com/questions/1113819/arrays-heap-and-stack-and-value-types and pay attention at some nice graphics at the bottom of the post,0,0.5
 "I'm apparently an idiot.  I think i moved them to the abstract class, and *removed* the fact attribute, and then (obviously) couldn't have them run from the derived type.   Ugh.  sorry about that.",0,0.5
 "Correct, we rely on OS to do DNS caching, which creates terrible perf for platforms that don't do DNS caching.",0,0.5
 "Yup it's a stupid copy-paste error, I made changes to one place but forgot it here.",1,0.5
 "wait hold up what now? #code is a parent class of #code? That seems... backwards. So every #code instance has basically an entirely empty #code as well? Including, technically, a null #code? That seems like a gross layering violation. Like a Profile should have an appearance, and possibly an unfocused appearance. I suppose the unfocused appearance should be a child of the profile's own appearance object, but the AppearanceConfig itself shouldn't need to know anything about the internals of a Profile.",0,0.5
-Oh maybe the regex is a little too forgiving...,0,0.5
-Okay I officially don't know wtf the regex is doing:,1,0.5
+Oh maybe the regex is a little too forgiving,0,0.5
+Okay I officially don't know wtf the regex is doing,1,0.5
 Tagging subscribers to this area: @github,0,0.5
-NativeAOT currently goes through a helper call whenever we need to access static fields. For this simple program:,0,0.5
-We generate:,0,0.5
+NativeAOT currently goes through a helper call whenever we need to access static fields. For this simple program,0,0.5
+We generate,0,0.5
 "It's not terrible, but also could be better. As far as I can see, JitInterface cannot express the exact way static fields are accessed in NativeAOT. I had a previous attempt to use the existing JitInterface facilities in https://github.com/dotnet/corert/pull/5131 (misusing the facilities that exist to support RVA static fields), but it didn't generate ""nice"" addressing modes and couldn't support GC statics (see the disassembly there).",0,0.5
 "I'm adding a way to do that with ""nice"" addressing modes. After this change, the above program compiles into:",0,0.5
-There's room for improvement:,0,0.5
+There's room for improvement,0,0.5
 * It would be nice if we could similarly inline these lookups when we're in shared generic code,0,0.5
-* I think the addressing mode could be more compact if RyuJIT generated a reloc with a delta on x64.,0,0.5
+* I think the addressing mode could be more compact if RyuJIT generated a reloc with a delta on x64,0,0.5
 "* It would be nice if we could do this if there's a static constructor. .NET Native could inline the ""did static constructor already run?"" checks. There was a previous attempt at that in https://github.com/dotnet/coreclr/pull/12420 (and corresponding https://github.com/dotnet/corert/pull/3962).",0,0.5
 Gross,1,0.5
 "Agreed.  Tihs is the problem with having hte parser be overly restrictive.  All it means is htat when people write totally reasonable code, that we end up with a terrible tree.  We want the parser to avoid contextual parsing as much as possible.",0,0.5
@@ -1474,22 +1476,22 @@ I mean we could have the type as -,0,0.5
 "We're looking up another method I expect always to exist in the platform assemblies. If it doesn't, the entire world is insane and I'm fine crashing.",0,0.5
 "Users who write longer #code text, but leave out #code because it was never visible to anyone before",0,0.5
 "Just wanted to chime in that this is the exact reason I have almost never used the #code tag, even that I have really _wanted_ to - the IDE has <strike>worthless</strike> lousy support for displaying documentation in pop-ups. Compare this with e.g. IntelliJ IDEA to see how I (and most likely the vast majority of developers) would have liked this to work.",0,0.5
-TL;DR; Thanks for fixing up old crap.,1,0.5
-It will always use a different semantic model instance then the one used by the compiler for method body binding.,0,0.5
-That seems... terrible.  Why does it do that?,1,0.5
+TL;DR; Thanks for fixing up old crap,1,0.5
+It will always use a different semantic model instance then the one used by the compiler for method body binding,0,0.5
+That seems... terrible.  Why does it do that,1,0.5
 "If we handle #code at all (by returning anything for a NCPAINT message), then the system assumes that we wanted to paint our nonclient area. Because it assumes we're doing _all_ the work, it does _nothing_. Unfortunately, the kernel is weird, so if the OS is doing nothing, the kernel still treats our window like a Windows xp/vista-like window, and the _kernel_ thinks that we have rounded top corners. The OS also won't paint our window shadow anymore, because it assumes we're doing that.",0,0.5
-Basically everything is terrible if we try doing that.,1,0.5
-@github Well I made a boo boo.  I had to remove my fork because I was stupid and didnt create a branch on this defect but wanted to work another one.  Was planning on only doing one and well one thing led to another :).,0,0.5
-So I did a fetch on 786 and tried to recreate the line with tabs and sure enough my end thinks they are tabs still.  This is a different computer with a new fetch and checkout.  Any ideas on what might be going on?,0,0.5
+Basically everything is terrible if we try doing that,1,0.5
+@github Well I made a boo boo.  I had to remove my fork because I was stupid and didnt create a branch on this defect but wanted to work another one.  Was planning on only doing one and well one thing led to another :),0,0.5
+So I did a fetch on 786 and tried to recreate the line with tabs and sure enough my end thinks they are tabs still.  This is a different computer with a new fetch and checkout.  Any ideas on what might be going on,0,0.5
 "Stupid me, forgot it is only in build.",1,0.5
 oh shit good catch,1,0.5
 "note: i imagine if you hover of this type name, the above looks terrible :)  if you are embedding fixed 'ascii' art explanations, ensure you wrap with something like #code so the xml doc pipeline properly renders.  (this applies to other docs).",1,0.5
 "Performance is _terrible_. Like beyond bad. ... If we could make nested context sensitive function calls much more performant to check, it's go a long way towards making merging this feasible.",1,0.5
-Is there a tracking issue or something of the sort for that work? I'm trying to get a sense for what would be involved in getting this over the finish line.,0,0.5
+Is there a tracking issue or something of the sort for that work? I'm trying to get a sense for what would be involved in getting this over the finish line,0,0.5
 "FWIW, the use-case I have for this is to strictly-type XML in accordance with a specific schema.",0,0.5
 "quick question, as the API has been approuved, and thinking about the summary, i have a terrible idea....",0,0.5
-This would make another PR i guess since this API Changed has been approuved already ?,0,0.5
-(i have no idea if it's possible) but does adding this makes sense:,0,0.5
+This would make another PR i guess since this API Changed has been approuved already,0,0.5
+(i have no idea if it's possible) but does adding this makes sense,0,0.5
 "(pseudo code, i have no idea if it's something good or bad since it's intrusive and also how properly speak english and being both nice and clear to the customer)",0,0.5
 "Perf doesn't care about gross ;) But it was just GYI, I don't think it matters here",0,0.5
 "nit: we could use this opportunity to produce distinct failure messages for these two cases.  Specifically ""You_cannot_rename_this_element""is terrible.  It would be better as ""You_cannot_rename_this_element_because_it_is_contained_in_a_read_only_file"" or ""You_cannot_rename_this_element_because_it_is_in_a_location_that_cannot_be_navigated_to"".  (can be done in the future).",0,0.5
@@ -1499,14 +1501,14 @@ Your code Is a pain to read,1,0.5
 This is a pain in the behind,1,0.5
 This still sucks,1,0.5
 Your app has a small #code,0,0.5
-You should see a message.,0,0.5
-You should see something like:,0,0.5
+You should see a message,0,0.5
+You should see something like,0,0.5
 This is #code,0,0.5
-Did you try rebooting?,0,0.5
-I love you for this!,0,0.5
+Did you try rebooting,0,0.5
+I love you for this,0,0.5
 We love you,0,0.5
-Why are you such a loser?,1,0.5
-How are you measuring the startup time?,0,0.5
+Why are you such a loser,1,0.5
+How are you measuring the startup time,0,0.5
 You are a twat,1,0.5
 You are a idiot,1,0.5
 You are a asshole,1,0.5
@@ -1514,7 +1516,7 @@ You are a git,1,0.5
 twat,1,0.5
 idiot,1,0.5
 asshole,1,0.5
-FileBufferingReadStream  is pretty terrible for performance. We need to fix the block size problems.,0,0.5
+FileBufferingReadStream  is pretty terrible for performance. We need to fix the block size problems,0,0.5
 "#code is ""shutdown writes, send EOF to peer"".",0,0.5
 "#code was ""wait for peer to acknowledge that shutdown"" which we found to be mostly useless so I believe we changed it to mean ""wait for peer to acknowledge that shutdown AND to shutdown their side too"". It has a terrible name. This is what I'd like to see changed to a #code.",1,0.5
 "Mel was a bit stupid here, remove 2 of these comments copies.",1,0.5
@@ -1522,23 +1524,23 @@ fuck them alll,1,0.5
 "Crap, before this will work we need to update the spa-templates submodule to reference the dotnet7 feed & ingest it. I'll update that repo now.",0,0.5
 "This is really gross and is screaming ""IDL"" and/or ""COM"" at me. Maybe #code just needs to become a CppWinRT module and be activated that way?",1,0.5
 "Or can we not do that because you're trying to make this work back to Windows 7? In which case, can it just be a classic COM interface definition or something?",0,0.5
-This confused the crap out of me until I saw the other code. Again wondering if a base type w/ derived type that doesn't really do anything at least keeps the hack isolated.,0,0.5
+This confused the crap out of me until I saw the other code. Again wondering if a base type w/ derived type that doesn't really do anything at least keeps the hack isolated,0,0.5
 "if an option is 0 (All), it will now just be ignored.",0,0.5
 Fuck. 😄 I need to learn to read. 😄,1,0.5
 "@github I'm stupid, wanted to do this on d16-8, looks like changing the target branch is a bad idea. I'll close and recreate.",0,0.5
-Problem is that we don't know what the user will use as a type. Suppose the following situation:,0,0.5
+Problem is that we don't know what the user will use as a type. Suppose the following situation,0,0.5
 "Of course, this is insane and not code that anyone would write, but it does indicate that the declared type of a field on the closure does not necessarily have to match the runtime type. So #code seems appropriate to me.",0,0.5
 I'm terrible at spelling 😦,0,0.5
 stupid me,1,0.5
 _holy crap you actually did it_,0,0.5
-I'm gonna throw this out here right now - the team is absolutely stoked that you were able to throw together a PR for this feature in _just three days_. That's really impressive.,0,0.5
+I'm gonna throw this out here right now - the team is absolutely stoked that you were able to throw together a PR for this feature in _just three days_. That's really impressive,0,0.5
 "I'm going to be the pre-emptive bearer of badish news - we're starting to make harder cuts about what is and isn't making it into the 1.0 release of the Terminal. As _awesome_ as this feature is, I'm going to go with my gut here and guess that this isn't going to make that cut unfortunately. That being said, we're still going to review this now and get feedback to you. Once this gets approved, we'll probably just hold in until we make an official 1.0 release branch, and then we'll get it merged immediately after that.",0,0.5
 There is no such thing as a stupid question :),0,0.5
 Don't be fooled by the terrible diff - that's in install_mono_toolset(),0,0.5
-Holy crap this helper is awesome.,0,0.5
-This is why #code has been acting so stupid.,1,0.5
+Holy crap this helper is awesome,0,0.5
+This is why #code has been acting so stupid,1,0.5
 What the heck is going on here? I'd love to have some inline documentation for when we do insane winrt things like this,0,0.5
-I didn't look into this in great detail. Any suggestions on how this could be done without making the new Stream gross?,0,0.5
+I didn't look into this in great detail. Any suggestions on how this could be done without making the new Stream gross,0,0.5
 "Yes. It's just a terrible sentence. Fixed to say ""container"".",0,0.5
 "I believe using explicit linked files is actually super terrible to maintain and port future analyzers/fixer/tests. After having attempted this both ways (using the existing add of linked files and then with shared projects), I think using shared projects is way easier for porting more analyzers/fixers as well as viewing the existing ported shared analyzers and fixers. Lets discuss both these approaches in the meeting today, I can open up the solution from this branch.",0,0.5
 "Regardless, as mentioned in https://github.com/dotnet/roslyn/issues/38480#issuecomment-578903218, I think neither of these are really good long term solutions and we should eventually just move these analyzers/fixers completely into CodeStyle layer and ship CodeStyle NuGet with the SDK.",0,0.5
@@ -1546,19 +1548,19 @@ I didn't look into this in great detail. Any suggestions on how this could be do
 "@github We actually have two sanitization passes currently, one from #code and one from #code. The #code is the more complete sanitizer so we probably don't need the marked one.",1,0.5
 "What worries me though is that by allowing markdown strings to use #code, we open up the surface area both in terms of security and presentation. Now an extension can use arbitrary css in hovers, including loading images or positioning content outside of the hover itself.",0,0.5
 Github's sanitizer for markdown previews strips out #code attributes for these reasons (and also I believe because #code could at one point be used in very old browsers to run scripts and do other super unsafe things),0,0.5
-yeah.  wtf.  i'm not sure what i was thinking.  we shoudl handle the disparate forms.,1,0.5
+yeah.  wtf.  i'm not sure what i was thinking.  we shoudl handle the disparate forms,1,0.5
 "noob cpp incoming question, it looks like these things are used in debugutil.cpp why are the includes here instead of in debugutil.cpp?",0,0.5
 "I do like keeping the main logic in CreateResponseHeaders. I think the current implementations of HasInvalidH2H3Headers and ClearInvalidH2H3Headers() are plenty efficient. You could even argue it creates less branching logic on the set-headers path compared to proactively avoiding setting them. We could microbenchmark, but I'm not too concerned about optimizing the case where invalid headers are being set as long as it isn't terrible.",0,0.5
 "Because I'm a terrible person and didn't review this soon enough, language version 8.0 is now the default so you should be able to drop this project reference and also remove the ""Regular8WithNullableAnalysis"" uses, because that doesn't exist anymore...",1,0.5
 "that looks insane, does that just set to #code to true the first time it's called then we just check #code",1,0.5
 Great! Just idiot thoughts,1,0.5
 "Crap, I meant the slash direction. I'll fix that.",1,0.5
-I begrudgingly accept this until quirking our APIs becomes widespread enough that we should pass a quirk struct into all of them uniformly so it's less gross.,0,0.5
-I'd really really love for this to not be totally insane.,0,0.5
+I begrudgingly accept this until quirking our APIs becomes widespread enough that we should pass a quirk struct into all of them uniformly so it's less gross,0,0.5
+I'd really really love for this to not be totally insane,0,0.5
 "#code? idk. When I get more time, I'm gonna set up a simple repro for the WinUI team to tell me exactly wtf is going on here.",1,0.5
 "this is the meat of where things changed.  unfortunately, the diff is terrible.  effectively teh logic is pretty simple:",1,0.5
-1. determine the expression we want to inline.,0,0.5
-2. find the reference locations to inline and inline there.,0,0.5
+1. determine the expression we want to inline,0,0.5
+2. find the reference locations to inline and inline there,0,0.5
 "3. if we had no conflicts, remove the declaration",0,0.5
 4. add warning annotations for things like side-effects or moving code into conditionally compiled methods,0,0.5
 hm... #code was not inlined and it's terrible if executed without it... 😢,0,0.5
@@ -1567,16 +1569,16 @@ hm... #code was not inlined and it's terrible if executed without it... 😢,0,0
 "* The build doesn't really support OS subgroups (i.e. #code, #code), it's a gross hack where the system thinks it's actually the OSGroup OS (Linux for musl), some magic autodetection code in a few shell scripts tells it otherwise and causes changes in build behaviour, and the RID gets overridden post-hoc via #code. I've removed this assumption in a few places and parsed #code, because it's not possible to autodetect the difference between Android and linux-bionic based on anything in the rootfs.",0,0.5
 "Sorry I was missing full context on the previous conversation: should this just be GetTextAsync? In theory still instant, but if we're wrong it's less terrible?",0,0.5
 (still OK with this more than TryGetText),0,0.5
-Removed. This was a sleepy me being stupid last night and just testing a variable named discard.,1,0.5
+Removed. This was a sleepy me being stupid last night and just testing a variable named discard,1,0.5
 Is it a terrible bother if I request @github as a reviewer for this one? He probably knows more than we do 😝,0,0.5
 @github glad you asked,0,0.5
 "well, at least we shouldn't have multiple caches... TypeConversionExtensions.KnownConverters, TCE.KnownConverterFactories, BindableProperty.KnownTypeConverter; and then we have NodeILExtensions.KnonwnCompiledTypeConverters",0,0.5
-Type Conversion happens at multiple places:,0,0.5
+Type Conversion happens at multiple places,0,0.5
 "- when applying a binding (this includes AppThemeBinding, DynamicResource, ...)",0,0.5
 "ColorTypeConverter and ThicknessTypeConverter do _not_ need to be cached in a known list, as they are attributed with a TypeConverterAttribute, they need to be in the KnownCOMPILEDTypeConverter as they're not attributed with the ProvideCompiledAttibute.",0,0.5
 "The only converter that can not be retrieved using reflection is UriTypeConverter as System.Uri is NOT attributed on .NET core 6 (even though System provides a UriTypeConverter that we should use now that we replaced our own base TypeConverter type by System.ComponentModel.TypeConverter. Side note, System.Uri is attributed in the net framework profile, go figure). so why do we whitelist ColorTypeConverter and EasingTypeConverter in BindableProperty.cs is something that need clarification.",0,0.5
 "I don't recall the details of why FontTypeConverter need to be whitelisted, but I recall that we almost got rid of Font as a property type in most (all?) of our controls (because compound properties are a mess and produce too many propertychange events, and redraw).",0,0.5
-We could/should cache the TypeConverters:,0,0.5
+We could/should cache the TypeConverters,0,0.5
 "Our own TypeConverters are known beforehand, but I'm not keen on maintaining a list of those (I'd prefer a sourcegen), but there's also the TypeConverters defined in 3rd party assemblies. Oh, and caching type converters isn't a solution for avoiding reflection, as TypeConverterAttributes on properties take priority over the ones defined on Type, but we could cache that too (using the PropertyInfo as key e.g.)",0,0.5
 "To summarise this digression on TypeConverters, here's a list of action points:",0,0.5
 "- [ ] Investigate the usage of #code in Controls. It's probably unused, in that case #code and the 2 caches in TypeConversionExtension could go away",0,0.5
@@ -1587,65 +1589,65 @@ We could/should cache the TypeConverters:,0,0.5
 LMK if there's a more idiomatic way to do this. i is noob,0,0.5
 Ack. That feeling when you realize you're an idiot :D,1,0.5
 "That's how I felt on Friday. In my case, I made the reverse mistake: I was correctly adding both C and D to B's transitive references, but forgot to update A too.",0,0.5
-Stupid linker. Fixed.,1,0.5
+Stupid linker. Fixed,1,0.5
 "@github I haven't tried this yet, but I'm wondering what it looks like after I have a new descriptor. Still, I need to destroy the old grid, right? Which will disconnect the whole workbench from the dom and reattach. Is that what you have in mind?",0,0.5
 "Also, today, I don't really have call layout on the whole grid when moving things around. The code is a bit gross, but the grid seems to handle calling layout on the appropriate things so there are no issues. However it seems like I would have to call a top-level layout every time a part moves with this approach. Is that not more expensive?",0,0.5
-Isn't the solution file at this point known to exist? (Aren't we already loading it?) Can this ever fail?,0,0.5
+Isn't the solution file at this point known to exist? (Aren't we already loading it?) Can this ever fail,0,0.5
 "(yes, I know this logic was there, but if we're deleting stupid code we mind as well delete more stupid code)",1,0.5
 "Ah, crap - you need to build this locally to update all the xlf files and include those changes.",0,0.5
 "ProjectIds returns an IReadOnlyCollection<T>, which generally isn't safe for iteration during mutating operations",0,0.5
 It shoudl def be safe though as per the roslyn Worspace invariants.  The ProjectIds of a Solution cannot change out from underneath you.  That would be a gross violation of the contract of Solution :),0,0.5
 "@github no i don't want it to move down to #code, either. Check out my edit. I want it to be DX only, which helps all of us.",0,0.5
-1 vote new API.,0,0.5
+1 vote new API,0,0.5
 "Oh, shit. I don't hate that. @github what do you think?",1,0.5
-2 votes new API.,0,0.5
+2 votes new API,0,0.5
 That said I don't have any strong opinions about it. Code can always be modified. 🙂,0,0.5
 "2 votes new API. 1 vote ""whatevs man, it's just code.""",0,0.5
-// Create a new #code method with more parameters only in DxEngine.,0,0.5
+// Create a new #code method with more parameters only in DxEngine,0,0.5
 "_renderEngine->UpdateFone(newDpi, _desiredFont, _actualFont, whatever we want to add);",0,0.5
 I like this. Would like to hear from @github before proceeding though,0,0.5
 "3 votes new API. 1 vote ""whatevs man, it's just code.""",0,0.5
-I'm fine also with adding a DXEngine only method with additional parameters and calling it directly until such later date that @github and @github make their thin-API data-driven renderer dreams come true.,0,0.5
+I'm fine also with adding a DXEngine only method with additional parameters and calling it directly until such later date that @github and @github make their thin-API data-driven renderer dreams come true,0,0.5
 "So I think that's 4 votes new API. 1 vote ""whatevs man, it's just code."" Sold.",0,0.5
 "same, I'm an idiot.",1,0.5
-It should be. I cherry picked the commit.,0,0.5
+It should be. I cherry picked the commit,0,0.5
 👍,0,0.5
-I didn't know about the forking and bots... I'm a noob with all this. Next time or should I create now?,0,0.5
+I didn't know about the forking and bots... I'm a noob with all this. Next time or should I create now,0,0.5
 "We typically prefer work (and pull requests) to be done in forks. It's fine for this PR, but if you could create the d16-7 PR using your fork that would be great! And we've branched d16-8 as well, so this fix needs to go there too.",0,0.5
-We found a similar bug in other extensions libraries #33998.  Since its just extension methods that folks aren't going to directly reference it's not a terrible type conflict.  I'd just suppress the error for now and file a bug.  If folks have a scenario for using the two types and notice the clash we can address it.,0,0.5
+We found a similar bug in other extensions libraries #33998.  Since its just extension methods that folks aren't going to directly reference it's not a terrible type conflict.  I'd just suppress the error for now and file a bug.  If folks have a scenario for using the two types and notice the clash we can address it,0,0.5
 "What do you suggest?  Removing is breaking, we could obsolete it and/or implement on top of System.HashCode?",0,0.5
 "Hey @github, I guess I can answer to that 😄",0,0.5
 "There are a couple places where I'm using that API in the MVVM Toolkit, and they're indeed in a performance oriented type.",0,0.5
 "They're only being used on values being of private types, coming from private fields, and guaranteed to be correct due to the implementation of the type itself, so the only way this could break is if a dev actually tried to mess up with the internal fields using reflection, which is something that not even types from the BCL guard against, as far as I can tell (eg. #code will break the type safety too in the #code property getter if a dev used private reflection to store some arbitrary object there).",0,0.5
 "In particular, there's a usage of the #code API in the MVVM Toolkit that just can't be worked around without having to sacrifice quite a fair bit of performance and more memory usage, which is this line [here](https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/79127cf6a76ea1b0673c0376e43d41f91b2df509/Microsoft.Toolkit.Mvvm/Messaging/StrongReferenceMessenger.cs#L400-L404):",0,0.5
-Basically I have the following situation:,0,0.5
+Basically I have the following situation,0,0.5
 "- I have this delegate type, which is used to register message recipients with the ability to specify both the recipient type (so the input to the lambda expression is already of the right type and they don't need to cast), and the message type:",0,0.5
 "- As you can see from the delegate, #code is always a reference type",0,0.5
-#NAME?,0,0.5
+#NAME,0,0.5
 "So doing that unsafe cast basically tricks the runtime into just calling the #code method of each actual handler just with an input #code type (as we don't know the type used in each handler here) - we're essentially invoking a contravariant delegate as if it was covariant in that input argument. Again this is always guaranteed to be a valid type cast due to how the messenger itself works - each recipient will always match the original #code constraint in each delegate being invoked. This way we get identical codegen to just invoking those handlers directly, even if we lack knowledge on each type in use.",0,0.5
-The alternatives I've considered here would've been:,0,0.5
+The alternatives I've considered here would've been,0,0.5
 "- Use #code, which is just terrible for performance/memory usage. We wanted to have the broadcast method have an amortized allocation cost equal to 0, and also to avoid using reflection completely in this implementation.",0,0.5
 "- Wrap each input handler in another one with just an #code parameter. This would've meant to completely defeat the whole point of structuring delegates this way to allow the C# compiler to cache them (as they're static), as we would've had to allocate a new display class capturing the input delegate every single time one was registered. Also each broadcast would've had twice the number of virtual calls, as each handler would've had to go through its proxy one doing the recipient cast first.",0,0.5
 "This is something I've actually talked about quite a bit with @github and @github too in the C# Discord server. Given the exact specifications of this type and the way it's implemented, using this trick should be perfectly valid, as all the various constraints and unsafe casts will always be guaranteed to be valid, so there will never be a type violation in doing so. This is really just a workaround for a lack of proper support for basically doing the equivalent of ""try to invoke this delegate with these inputs, and just throw if they are not valid"". With the exception that here we already know the inputs are valid, so we don't even check.",0,0.5
 "In an ideal world (as in, with you guys having unlimited time and budget to implement all sorts of proposals even for less requested features), my idea was that #code could be implemented as a JIT intrinsic, with the EE engine emitting the code there to just do safe casts of the inputs and throw otherwise - that way all the reflection would be avoided and the resulting codegen would be almost the same as just #code, with the only difference being the checks for the input parameters and boxing of value type parameters, if any, but that'd be perfectly acceptable. This is just a way to achieve that with the current runtime 🚀",0,0.5
 "On the other hand, as a result of this and a number of other (less unsafe) optimizations this new implementation is both much faster than all other competitor types from other common libraries, and using virtually no memory at all for broadcasts:",0,0.5
 Hope this helps to clarify why the usage of that arguably very niche API in that library in particular 😊,0,0.5
-This mildly concerns me - we've ran into insane bugs in the past where not zero-initializing something has resulted in bugs.,0,0.5
+This mildly concerns me - we've ran into insane bugs in the past where not zero-initializing something has resulted in bugs,0,0.5
 "That first parameter being #code hits me 90% time when I use it, because I forget to pass #code here and then get stupid behavior a I have args shifted. This helps me a little bit, but I'm ok to revert it or to do something else, if you have an idea.",0,0.5
 "Consider a method that does 100 string comparisons against constant strings. Are all these 100 string comparisons going to be optimized, without hitting inliner's budget?",0,0.5
 "@github So the budget is common for all the callees for a specific root and it gets eaten very quickly with string.Equals, e.g.:",0,0.5
 "Also, it would be interesting to measure JIT time of a method like this (before/after).",0,0.5
 "since it can't do 100 Equals I don't see anything terrible and in general I guess there are not so many, I also tested the test I added - no visible effects.",0,0.5
-What is nice is that for non-unrollable cases jit ignores those calls as it is able to remove simple dead branches during import.,0,0.5
+What is nice is that for non-unrollable cases jit ignores those calls as it is able to remove simple dead branches during import,0,0.5
 "Any opinion on this? It feels great to be able to declare rules to unroll stuff in pure C# but yeah, several long equals can eat inliner's budget and we won't be able to inline other stuff in the current root.",0,0.5
 "Suggestion: Could we make all these offsets consts into an internal shared class that everybody links so that we can see the ordering in one place? It might sounds stupid, but it's really hard to think about the ordering of the system when it's distributed across classes. I also understand that this is kind of unrelated and a nit.",0,0.5
 Wow this is kinda gross 😄,1,0.5
 "Noob question, the server and client OS share the same version prefix, so is it possible that windows 10/11 catch up with server? Or are these number incremented verry rarely. Like not on every windows update, but as a product version.",0,0.5
 Because I'm terrible at all the WPF stuff and didn't even realize I can do  #code? :),0,0.5
-Thanks for the remind. This one is about allowing the core markdown renderer to display #code which is sanitized by #code. I'll revert the change for now and see ppl's feedback.,0,0.5
-wtf...,1,0.5
+Thanks for the remind. This one is about allowing the core markdown renderer to display #code which is sanitized by #code. I'll revert the change for now and see ppl's feedback,0,0.5
+wtf,1,0.5
 ## Friday Spec Brownbag Quick Summary,0,0.5
-Today we had a meeting about this spec. Here's some quick notes of how the discussion went.,0,0.5
+Today we had a meeting about this spec. Here's some quick notes of how the discussion went,0,0.5
 "- Unanimous ""launch inside the tab"", not a new window",0,0.5
 ### Preview Window in Appearance Page,0,0.5
 "- Unanimous yes. Do this. TermControl with a new connection that isn't real, just filled with some dummy sample text like what people might use (emojis, powerline fun, text tables, colors, etc.)",0,0.5
@@ -1662,45 +1664,45 @@ Today we had a meeting about this spec. Here's some quick notes of how the discu
 - Concern with how to display/present the commands that people might not know about (easily buried in a dropdown/combo),0,0.5
 "OK, so after talking this one out with other ppl on the team, I believe this was a stupid suggestion on my side.",1,0.5
 "IDEs ask for errors on files in no specific order. with this in place the error will keep appearing and disappearing randomly. i think we are better off having the error on every use. We already report errors on every use for decorators. so this should just be the same. I think we can just remove this check, and keep the error.",0,0.5
-Sorry for the bad suggestion.,0,0.5
+Sorry for the bad suggestion,0,0.5
 "Maybe separately, we should do better on tuples since this is so stupid.",0,0.5
 "I deleted the comment because we discussed it offline. To make you look less insane, I was asking why it wasn't called #code.",0,0.5
 "Tagging this ""needs design review"" for one concern about whether we want to be overloading go to _definition_ for this particular feature, since I don't think I would imagine this really correlates to a ""definition"" at all. We might be able to make some UI affordances to the user to help out what is going on (change the text of the right click menu to say ""go to control flow destination"" or something to that effect when you're actually on one of these tokens).",0,0.5
-Also a few things that might be helpful:,0,0.5
+Also a few things that might be helpful,0,0.5
 "1. Should invoking on return in a method jump to the invocation of that method if there's one, or show the selection if there's multiple? The local function case at least might be handy.",0,0.5
 "2. Should invoking throw jump to a catch block, at least if there's a matching one in the method? (The control flow analysis can of course get insane here but maybe the same-method case could still be useful....?) #Closed",0,0.5
 "~The GitHub app is terrible so I can't review properly, but test 5 uses a function type returning #code. That's probably a mistake.~",0,0.5
 "Yea, you could(should) definitely expose that method on AppKeyBindings. Parsing them again would be insane :P",0,0.5
 "I'd rather you do it in this PR, rather than blocking your PR on mine getting in",0,0.5
 "Thanks, @github",0,0.5
-I've just tried the sequence of [the above GIF](https://github.com/microsoft/terminal/pull/8215#issuecomment-729949956) in a PowerShell:,0,0.5
-Then quickly minimized the window and nothing happens. I.e. nothing flashing.,0,0.5
-I'm using:,0,0.5
-Probably I'm just doing something stupid and/or missing some plain obvious things.,0,0.5
-Trying it from a [.NET console application](https://github.com/microsoft/terminal/issues/8713#issuecomment-756181568) with:,0,0.5
-also does not flash the task bar icon.,0,0.5
+I've just tried the sequence of [the above GIF](https://github.com/microsoft/terminal/pull/8215#issuecomment-729949956) in a PowerShell,0,0.5
+Then quickly minimized the window and nothing happens. I.e. nothing flashing,0,0.5
+I'm using,0,0.5
+Probably I'm just doing something stupid and/or missing some plain obvious things,0,0.5
+Trying it from a [.NET console application](https://github.com/microsoft/terminal/issues/8713#issuecomment-756181568) with,0,0.5
+also does not flash the task bar icon,0,0.5
 "OK, I think I get it now:",0,0.5
 "The [""BellStyle"" setting](https://docs.microsoft.com/en-us/windows/terminal/customize-settings/profile-advanced#bell-notification-style) was not set explicitly, thus resulting in only a sound (which was not hearable since I turned of all system sounds).",0,0.5
-After configuring the CMD type to this:,0,0.5
-. image](ht.,0,0.5
-My C# console application was able to make the task bar flash/be lightened when using this:,0,0.5
-Resulting in this effect:,0,0.5
+After configuring the CMD type to this,0,0.5
+. image](ht,0,0.5
+My C# console application was able to make the task bar flash/be lightened when using this,0,0.5
+Resulting in this effect,0,0.5
 "I'm still unable to do the same for PowerShell and #code but since I do need it for CMD only, not PowerShell, this is sufficient for me.",0,0.5
 "After reading [Dustin's reply](https://github.com/microsoft/terminal/pull/8215#issuecomment-1133933312), this one worked correctly in PowerShell:",0,0.5
-This is a really gross pattern.  Can we rename this to something like EnsureInitialized and not do the ref to a field thing?,1,0.5
+This is a really gross pattern.  Can we rename this to something like EnsureInitialized and not do the ref to a field thing,1,0.5
 "There is one ***huge*** issue with BigInteger as it stands currently, its default constructors.",0,0.5
 "The BigInt Class' constructors are all conversions to other datatypes making it inefficient and limited while BigInt *already* has a method coded in which uses *string* input **and is really what you should use when actually utilizing BigInt** called the #code method. The issue of the type conversion is *especially* magnetized for BigInt because of how it was intended for and why it was made, as the official microsoft documentation of BigInteger states (https://docs.microsoft.com/en-us/dotnet/api/system.numerics.biginteger?view=netcore-3.1)",0,0.5
-The BigInteger type is an immutable type that represents an arbitrarily large integer whose value in theory has no upper or lower bounds.,0,0.5
+The BigInteger type is an immutable type that represents an arbitrarily large integer whose value in theory has no upper or lower bounds,0,0.5
 "which is unlike every other type in the default constructor which means simply writing #code **will not** work because you aren't explicitly trying to convert the number to the #code datatype which also still has a max value, 179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368, but it is large enough to handle most things, however, numbers will not get automatically converted to double type, they need to be explicitly defined with the ""d"" suffix like #code but as double still has it's limits, this still goes against the purpose of Bignteger since as soon as you do #code the double datatype will stop working. The biggest ""*inexplicitly defined type*"" would be the uLong type which has the highest value of a measly #code. Since the constructor will always attempt to convert the number to a different type, as it stands it is",0,0.5
 1. Inefficient; tries to convert the arguments to another datatype and go through their constructors which also will cause longer computation times and,0,0.5
 "2. Has limitations; it will not work when trying to define an actual ""arbitrarily large integer"" like tested  by multiple people in this Stack Overflow question (https://stackoverflow.com/questions/62974138/bigint-inconsistencies-in-powershell-and-c-sharp)",0,0.5
 "So these constructors go against how BigInt is supposed to be by design, a datatype for *arbitrarily large integers* and having numbers too big for the base constructor goes against what BigInt is supposed to be. However, BigInt *can* handle these ""arbitrarily large integers"" and *can* handle infinitely large things with the parse method. The #code method takes string arguments so it is theoretically infinite there and works properly. So why have that as just a method? Why not turn that into a constructor? Isn't that just stupid to not have it as a constructor if it literally satisfies what BigInt is supposed to be when as it currently stands does not? You already have all of the code for the #code method so why not just use it? Just copy + paste, anyone can do this! If the #code method *does* work as intended and how BigInt is supposed to be but the constructors can't, why wouldn't you just add the #code method as a constructor for string overloads?",0,0.5
-When can this fix be expected or is there a temporary workaround? Android user experience is terrible without this feature.,0,0.5
+When can this fix be expected or is there a temporary workaround? Android user experience is terrible without this feature,0,0.5
 "We are now ignoring ""unknown"" errors. There are no tests for this, because these errors are unknown and therefor we don't know how to reproduce it, but we definitely should not be swallowing these.",0,0.5
 "Assuming #code is 0 given an unkown error (which seems like a safe bet), then the error will get logged as a FIN which is terrible for debugging.",0,0.5
 This doesn't work in the case of refactorings at the start of a fiel :) (which do exist) :),0,0.5
-I don't follow.,0,0.5
-Can you point to what you mean?,0,0.5
+I don't follow,0,0.5
+Can you point to what you mean,0,0.5
 "Imagine [this](https://github.com/dotnet/roslyn/pull/37777/commits/b82e2c2baa57fe50af62353e3a1470ca915dba2b#diff-a2c30b83123c3cb46ac84dae8175bc4bR24) accepts null and we want to pass #code [here](https://github.com/dotnet/roslyn/pull/37777/commits/b82e2c2baa57fe50af62353e3a1470ca915dba2b#diff-4b18194545a98c011598321cbfa1dd9fR68) (carries info ""didn't register specific TextSpan"") .  The #code [just calls](https://github.com/dotnet/roslyn/pull/37777/commits/b82e2c2baa57fe50af62353e3a1470ca915dba2b#diff-4b18194545a98c011598321cbfa1dd9fL86) #code lambda with given parameters and so if we want to call it with #code the [lambda](https://github.com/dotnet/roslyn/pull/37777/commits/b82e2c2baa57fe50af62353e3a1470ca915dba2b#diff-4b18194545a98c011598321cbfa1dd9fR30) needs to be of type #code (has to accept nullable #code).",0,0.5
 "The lambda, however, isn't an implementation detail. It gets set in [*public* constructor](https://github.com/dotnet/roslyn/pull/37777/commits/b82e2c2baa57fe50af62353e3a1470ca915dba2b#diff-4b18194545a98c011598321cbfa1dd9fR52). And that leaks the information that the registration should somehow work with Nullable #code 🤷‍♂️.",0,0.5
 "It's not terrible, nobody outside probably uses the constructor. But it _just feels weird_. Either have it nullable explicitly in #code (but that communicates wrong idea about it being optional) or have it nowhere.",0,0.5
@@ -1711,28 +1713,28 @@ Note: we [still support](https://github.com/dotnet/roslyn/pull/37777/commits/b82
 "**edit:** everything is working now, see https://github.com/microsoft/terminal/pull/10972#issuecomment-907345963",0,0.5
 "I took a pass at trying to get multi window saving working (didn't start on loading yet, which seems easier all things considered). The initial behavior that I started to implement was to just save the layout of all windows every #code seconds and/or when the last window closes.",0,0.5
 Roughly the architecture/call stack as currently implemented is,0,0.5
-monarch app host calls GetAllWindowLayouts -> propagate to monarch -> for each peasant call GetWindowLayout -> peasant triggers GetWindowLayoutRequested -> window manager -> app host handles event -> calls logic/page -> back up to peasant -> monarch returns back down to app host -> call logic to save in ApplicationState.,0,0.5
+monarch app host calls GetAllWindowLayouts -> propagate to monarch -> for each peasant call GetWindowLayout -> peasant triggers GetWindowLayoutRequested -> window manager -> app host handles event -> calls logic/page -> back up to peasant -> monarch returns back down to app host -> call logic to save in ApplicationState,0,0.5
 The WIP commit is https://github.com/microsoft/terminal/commit/fa54b144acd94e224535d671240d37f4bde8564c,0,0.5
 "I spend an excessive amount of time trying to get a stupid #code returned up the chain to the peasant, before  finally giving in and making a managed class that just wraps a string.",0,0.5
 "Unfortunately, I hit a wall as soon as I got the monarch window working because I needed to make the event async to handle switching to/from the ui thread since peasants on everyone except the monarch have different threads. This comment sums up my current thoughts and tribulations",0,0.5
 "It is possible that after having looked at this for the last 8 hours I am getting tunnel vision and missing an easy answer, in which case I would love to hear it. Definitely open to ideas of other approaches.",0,0.5
 "ok, I'm stupid, is a key, I can't parse english: 'The **value** of this **key**'. To the value if a double.",1,0.5
-It should be. I cherry picked the commit.,0,0.5
-I didn't know about the forking and bots... I'm a noob with all this. Next time or should I create now?,0,0.5
-python3 wtf.,1,0.5
-Is there an easy way to run on the same hardware? Also do I need to manually patch bits and run before and after?,0,0.5
+It should be. I cherry picked the commit,0,0.5
+I didn't know about the forking and bots... I'm a noob with all this. Next time or should I create now,0,0.5
+python3 wtf,1,0.5
+Is there an easy way to run on the same hardware? Also do I need to manually patch bits and run before and after,0,0.5
 "Would like a comment that this is test-only. I can imagine people doing really terrible things with this thinking this is a ""feature"".",0,0.5
 (but then I apparently ignored the rest of your comment because I'm stupid),1,0.5
 "Yeah if it's a directory, I'd have like",0,0.5
 #code <-- to explain WTF the files mean,1,0.5
-or whatnot.,0,0.5
+or whatnot,0,0.5
 "uint options seems correct since a C# int is a C long, so a C# uint is a C unsigned long:",0,0.5
-That is only true on Windows (i.e. C #code is always 32-bits). On non-Windows the #code is typically 32-bits on a 32-bit CPU and 64-bits on a 64-bit CPU. This is a terrible thing to discover so in .NET 6 we introduced [#code](https://github.com/dotnet/runtime/pull/46401). A big thanks to @github for pushing on it.,0,0.5
-The #code is correct.,0,0.5
+That is only true on Windows (i.e. C #code is always 32-bits). On non-Windows the #code is typically 32-bits on a 32-bit CPU and 64-bits on a 64-bit CPU. This is a terrible thing to discover so in .NET 6 we introduced [#code](https://github.com/dotnet/runtime/pull/46401). A big thanks to @github for pushing on it,0,0.5
+The #code is correct,0,0.5
 Okay so,0,0.5
 1. this is insane,0,0.5
 "2. it adds 90 test cases, so that makes me 😄",0,0.5
-255 now that I went through all of the positions 😉. AND I still need to add some for word navigation.,0,0.5
+255 now that I went through all of the positions 😉. AND I still need to add some for word navigation,0,0.5
 "3. I don't really know powershell all that well, but the code seemed easy enough to follow, and was documented well enough that I wouldn't totally hate myself if I needed to add another case",0,0.5
 "4. this doesn't run automatically as part of the build, this has to be run manually. That definitely cuts down on some of the complexity, which is good. IMO generating the tests automagically as part of the build just ain't worth it.",0,0.5
 "Yeah, and we're not really changing these tests all the time. I did just add a ""nice to have"" where it all goes to a .g.cpp file though. So this process is now so much easier!",0,0.5
@@ -1747,7 +1749,7 @@ Okay so,0,0.5
 "OK, I found the problem -- I'm stupid, I forgot that the pull request that referenced this package hasn't been merged yet.",1,0.5
 "@github Comments from @github were only some renaming of tests and spacing, and discussion on certain doc comments. I tried to edit them from mobile, but hit the wrong buttons (it's really quite tricky to delete one line in a file).",0,0.5
 "He has some other concerns about the api, but I'd think we shouldn't revisit the api right now. Could you resolve any open stuff please? It's terrible to do from mobile ;).",0,0.5
-Shit. I guess I cannot pick this up...,1,0.5
+Shit. I guess I cannot pick this up,1,0.5
 "Ah, crap, I forgot to fix this in the regular job. Will go do that now",0,0.5
 "This doesn't seem like a terrible idea, though are you cool if we punt that for the v1 at least? That seems like refactoring we could come back through on a second pass and do 🤔",0,0.5
 "Better than what we have now I suppose. Kinda gross to have 4, but it is what it is.",0,0.5
@@ -1772,27 +1774,27 @@ Same for #code https://www.diffchecker.com/7o91kyyE,0,0.5
 "Misc: https://www.diffchecker.com/olDdSxqM, https://www.diffchecker.com/XddHJSrd, https://www.diffchecker.com/3I81EWAo",0,0.5
 "There are cases where ExtendedDefaultPolicy doesn't inline what was inlined by the previous inliner - I tried to avoid it, but there were cases where I'm not sure we should inline, e.g this call https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/IO/Directory.cs#L63 is inlined despite being quite complex: https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/IO/FileSystem.Attributes.Windows.cs#L25-L35",0,0.5
 "Old inliner detected here ""arg feeds const test"" and added a big multiplier. It did so because IL scan was not quite accurate and had many false positives. However, this method will still be inlined with PGO (and I am sure we have one for this in the static profile we ship). **UPD** I slightly added some boost in https://github.com/dotnet/runtime/pull/52708/commits/05a19e57d879bf9ba9d271a7bfb8efeb2b97c58c.",0,0.5
-These are the cases where inlining increases the size but hopefully for better performance.,0,0.5
+These are the cases where inlining increases the size but hopefully for better performance,0,0.5
 "InlineTree diff: https://www.diffchecker.com/nEAcbTWc It decided to inline #code here (e.g. because of ""non-generic code calls generic"").",0,0.5
-Diff https://www.diffchecker.com/KgWTWBug - it inlined all #code calls.,0,0.5
+Diff https://www.diffchecker.com/KgWTWBug - it inlined all #code calls,0,0.5
 "Overall I don't see anything terribly wrong so far (e.g. terrible spills because of too-many-locals), I spent the whole week on fixing the regressions and now it's more or less fine.",0,0.5
 "Performance benefits aren't as good as they used to be with a way more aggressive inliner but I'm going to investigate what exactly led to such improvements and send separate PRs. At least currently I don't see any impact on ""time to first request"", I'll publish the first results once my [script](https://gist.github.com/EgorBo/a1ab453bf41a5369aa54b4c4fba6bea5) finishes.",0,0.5
-@github you can pick any method from the jit-diff and I'll explain with the diffs what exactly happened.,0,0.5
-gross. Can we think of better ways to organise and name this functionality?,0,0.5
+@github you can pick any method from the jit-diff and I'll explain with the diffs what exactly happened,0,0.5
+gross. Can we think of better ways to organise and name this functionality,0,0.5
 this seems like pretty gross overkill :D,0,0.5
 "I would consider keeping this test as #code considering that the test above, #code, which uses a similar code minus the insane amount of dictionary instances, is already signaled to run on #code.",0,0.5
-Agreed. That sounds good.,0,0.5
+Agreed. That sounds good,0,0.5
 "Still, I need to destroy the old grid, right?",0,0.5
 "Correct, though all the views' DOM nodes would be reused: they would just be reparented.",0,0.5
 "Also, today, I don't really have call layout on the whole grid when moving things around. The code is a bit gross, but the grid seems to handle calling layout on the appropriate things so there are no issues. However it seems like I would have to call a top-level layout every time a part moves with this approach. Is that not more expensive?",0,0.5
-No need to call layout when the inside of the grid changes. The contract with layout is: you call it when the size (or position) of the entire grid box changes.,0,0.5
+No need to call layout when the inside of the grid changes. The contract with layout is: you call it when the size (or position) of the entire grid box changes,0,0.5
 "this was to appease github, which shows a terrible diff otherwise :'(",0,0.5
 "Yeah, just the first time. I was mirroring the existing ""Enter outlining mode when files open"", though granted I think thats terrible wording too :)",0,0.5
-The first change adds CNS_INT long 0 Fseq[_00] for source field in the field by field assignments even when offset is 0.,0,0.5
+The first change adds CNS_INT long 0 Fseq[_00] for source field in the field by field assignments even when offset is 0,0,0.5
 "Hmm, I suspect that the ""proper"" way to do this is to add the address to the ""zero offset field map"". But then I happen to think that this kind of side maps are a terrible idea and that the it's best to keep this information in the IR, in special nodes - #code and #code. Basically #codes with field sequences but without suffering from #codes unary/binary split personality disorder. #code should do, with some extra special cases. Haven't checked the actual changes yet but I suppose you may want to make such nodes non-CSE, 0-size/execution cost, 0-level in eval order etc.",0,0.5
 "Optimize ADD(val, 0) in lower.",0,0.5
-Maybe this will also fix 13548?,0,0.5
-that's insane.. there should be a warning comment before every single local function?,0,0.5
+Maybe this will also fix 13548,0,0.5
+that's insane.. there should be a warning comment before every single local function,0,0.5
 "Yeah this is a terrible hack. I think I'll open another PR first where I rename #code into something like ""UseAlphaForBackground(bool)"" or something. This change is needed, because this only works in #code due to random chance and depends on the fact that DxEngine defaults to ClearType, which AtlasEngine can't yet.",1,0.5
 "Urgh. Yeah, so there's 2 parts here:",0,0.5
 ## anchorMode: Toggle,0,0.5
@@ -1813,18 +1815,18 @@ that's insane.. there should be a warning comment before every single local func
 "Sorry, didn't see this. GitHub mobile does a terrible job of notifications :)",0,0.5
 "The elastic annotation is added by #code which is called from the separated list constructor, so avoiding that by preserving the existing comma tokens solves this, and is much easier to boot.",0,0.5
 git,0,0.5
-Why are you such a pain to talk to?,1,0.5
+Why are you such a pain to talk to,1,0.5
 You are a pain to me,1,0.5
 I have no faith in you,1,0.5
 I have no faith in this code,1,0.5
 "I like the way you code, you got this",0,0.5
 I have no faith in this at all,1,0.5
 https://github.com/dotnet/roslyn/pull/26793#discussion_r187782708,0,0.5
-note: as per my conversation with @github i think the case that VB is handling is incredibly esoteric. I would be ok with having VB just checking for that case and not offerring invert-if if it helps simplify the rest of the algorithms here. I think it's a practically irrelevant case in practice and i would be fine with no invert-if for it.,1,0.5
+note: as per my conversation with @github i think the case that VB is handling is incredibly esoteric. I would be ok with having VB just checking for that case and not offerring invert-if if it helps simplify the rest of the algorithms here. I think it's a practically irrelevant case in practice and i would be fine with no invert-if for it,1,0.5
 This is an unfortunate consequence of having PRs drag on for so long.  We literally forget about the conversations we've had on these very topics. :),1,0.5
-@github This local variable will be released in the end of method with the help of garbage collector.,0,0.5
+@github This local variable will be released in the end of method with the help of garbage collector,0,0.5
 "Again I don't think we need a separate method for this, and ideally conhost would support some version of the ""restore default"" functionality too, but worst case the existing behaviour should remain unchanged. We definitely shouldn't be returning false without doing anything.",1,0.5
-This will replace the way I was using #code in the GHPRI extension to determine the best remote to create a permalink for.,0,0.5
+This will replace the way I was using #code in the GHPRI extension to determine the best remote to create a permalink for,0,0.5
 "The old way was to get the world using #code for a commit then do filtering and sorting based on the ""best"" remotes and branches. For microsoft/vscode, this always takes >10 seconds.",0,0.5
 "The new way would be to make the ""best"" patterns (remote+branch combos) then try to #code for each of these patterns. Best case, the first pattern returns a successful branch, which should only be a few (I think I've seen 2 or 3 seconds max) seconds. Worst case, we test all patterns (likely less than 6).",0,0.5
 "Now for a worst-case example, using the _Solarized Dark_ color scheme.",0,0.5
@@ -1836,58 +1838,58 @@ This will replace the way I was using #code in the GHPRI extension to determine 
 "I'm wondering whether we should do something a little more subtle for possible values of Length. As this PR stands, we're breaking some existing scenarios (see example below).",0,0.5
 "I'm thinking we could do something like for nullability, whereby if you explicitly test for null on a non-nullable value then we take it seriously expand the value's domain (pure null tests).",0,0.5
 "The analog here would be that if you do a test for some negative value of Length, then we expand its value domain to include negative values.",0,0.5
-I think that would avoid the breaking change.,0,0.5
-This is not blocking this PR. Probably needs more reflection and discussion with LDM.,0,0.5
+I think that would avoid the breaking change,0,0.5
+This is not blocking this PR. Probably needs more reflection and discussion with LDM,0,0.5
 "I only see one caller to Pump.  Since we'll throw if #code is null, it shouldn't be declared as null-accepting.  At worst, we're just moving this #code to the caller where they're asserting it's not null.",0,0.5
 "Digging deeper, the #code parameter can never be null (which is good, or we'd have a pending exception here).",0,0.5
-I looked at my usual corpora [1] to see which strategy is best. I started by considering three options:,0,0.5
-I found all comments containing #code and dumped the list of tags from each comment.,0,0.5
-6 projects use the unsupported callback-like typedefs compared to 3 projects that use local typedefs.,0,0.5
+I looked at my usual corpora [1] to see which strategy is best. I started by considering three options,0,0.5
+I found all comments containing #code and dumped the list of tags from each comment,0,0.5
+6 projects use the unsupported callback-like typedefs compared to 3 projects that use local typedefs,0,0.5
 "Additionally, I observed plenty of unassociated #code comments that were not separated by a newline from the next element, though the median next element was another comment.",0,0.5
 "In the future, if we decide to support callback-like typedefs, then (1) would stop incorrectly showing the callback-like typedefs. The code to implement this wouldn't be large, although I think there isn't much demand.",0,0.5
 "@github I tried the mono ""HelloWorld' sample (src/mono/samples/HelloWorld) with the interpreter on linux-x64 (#code in that directory) in a debug build of mono (#code)",0,0.5
 It's dying on this line,0,0.5
 "I ran it in GDB and got a ""stack trace"" of the frames:",0,0.5
-(And I think we're in the pinvoke wrapper for #code - going up a few more frames I see us in #code).,0,0.5
+(And I think we're in the pinvoke wrapper for #code - going up a few more frames I see us in #code),0,0.5
 "*Update* actually since it's a #code that's failing, it's probably not that #code is bad, but something we're doing with #code",0,0.5
 ~~So I think we're getting garbage for #code near here:~~,0,0.5
 "I'm not sure why that might be, yet",0,0.5
-I think the interpreter doesn't like #code for some reason:,0,0.5
-Options I see for this:,0,0.5
+I think the interpreter doesn't like #code for some reason,0,0.5
+Options I see for this,0,0.5
 1. What I did here (clear dupes of each attribute as it's added) - simple and O(N^2),0,0.5
 2. Clear dupes of *all* attributes for an element/component when it's closed - somewhat simple and also O(N^2),0,0.5
 "3. Use a HashSet - simple, requires extra data/hashing and still kinda worst-case O(N^2) because removing from an array is O(N)",0,0.5
 "Basically I felt like keeping the data in the *always consistent* state was the best thing overall. Without doing dedicated perf work around this specific feature, I don't have a clear insight into which of these are the best. That seems like a good thing to do some other time.",0,0.5
 "Seriously though, should we start all our interface summaries with ""Defines an interface""? Seems obvious/redundant. Even just ""An interface"" would be slightly better.",1,0.5
-We are seeing the same issue in the 'release/5.0-preview1' branch and need this fix there too.,0,0.5
+We are seeing the same issue in the 'release/5.0-preview1' branch and need this fix there too,0,0.5
 1. Re-enable this build step everywhere,0,0.5
 2. Find some way to run this build step when the site extension may be affected,0,0.5
 "- Worst case, could have a separate pipeline developers could execute when they suspect it's needed e.g. for this PR and the mega merge",0,0.5
 "This isn't incredibly urgent. But, might be nice to get it into 2.1.28 if ProdCon hasn't reached this repo by the time the changes are approved and validated.",0,0.5
-How can we help investigate?,0,0.5
+How can we help investigate,0,0.5
 "For clarification, a movzx of 8-bit to 32-bit can sometimes be elided entirely by the processor. In the worst case it's a 1/4 nanosecond latency on modern CPUs.",0,0.5
 "A movzx of 16-bit to 32-bit can never be elided by the processor. In the worst case it's a multi-cycle latency, as you have the cost of the operation _and_ the fact that this instruction operates on a dedicated port separate from many other ALU instructions. So that's a potential pipeline stall that affects anybody who will end up reading this value after it's computed.",0,0.5
 "Hmm, is this going to work right? If this is reflecting against the compiler's object, but we're linking a copy into our project, is this going to fail the ""is"" check because the types won't unify? note the reflection before wouldn't have cared in the slightest.",1,0.5
-The prior reflection not throwing asserts or something if it failed to me is incredibly suspicious too since we could have silently broken this in other ways.,0,0.5
-I don't think this loop is critical for performance as it's only executed once and it's very likely that this information is needed later anyway.,0,0.5
+The prior reflection not throwing asserts or something if it failed to me is incredibly suspicious too since we could have silently broken this in other ways,0,0.5
+I don't think this loop is critical for performance as it's only executed once and it's very likely that this information is needed later anyway,0,0.5
 In addition #code is only available in the scope of this function. I would need to move it to an outer scope to access it later. I'd like to avoid that as it increases the likelihood to retain references to old sourcefiles that could otherwise be garbage collected,0,0.5
 "Correct, the current implementation does not write all the bytes. The tests were failing without these Clear calls, because the rented arrays had garbage from previous usages.",0,0.5
 "The TypeScript generating this was #code. Garbage in, garbage out?",1,0.5
 "I'm not sure if anyone can confirm that doing a manual GC.Collect() between test runs causes the tests to pass, but that was my experience, so I believe I have found the problem.  It looks like the issue is reference counting on the COM interfaces.  The documentation for Marshal.GetObjectForIUnknown(IntPtr) states:",0,0.5
-This method wraps IUnknown in a managed object. This has the effect of incrementing the reference count of the COM component. The reference count will be decremented when the runtime performs garbage collection on the managed object that represents the COM object.,0,0.5
+This method wraps IUnknown in a managed object. This has the effect of incrementing the reference count of the COM component. The reference count will be decremented when the runtime performs garbage collection on the managed object that represents the COM object,0,0.5
 "In SafeHandles.cs, there are three calls to Marshal.GetObjectForIUnknown() that create a local variables that disappear into the ether and never have Marshal.ReleaseComObject() called on them (until garbage collection).  In my tests, adding a Marshal.ReleaseComObject() call to each of these will fix the issue.  For example:",0,0.5
 "Like I said, I believe this fixes the issue (presumably, the right way) and should allow this PR to be merged.  Please let me know your thoughts.  It'd be great if we could get this merged soon.  Thanks.",0,0.5
 @github,0,0.5
 "Worst case, we can always add to the #code enum that requires you to configure your queue for delegation ahead of time and avoid opting everyone into the new behavior",0,0.5
-What happens if another await is added while the blocking Run is used? Is there any negative side effect?,0,0.5
+What happens if another await is added while the blocking Run is used? Is there any negative side effect,0,0.5
 "I'm assuming that's the ""worst case"" where one extra blocked thread for the lifetime of the application.",0,0.5
 "Previously all the root helper methods for parsing paths returned #code, which is a tuple of #code. I didn't use this type for AnalyzerConfig because they can never be script files. Neither can EmbeddedFiles or AdditionalFiles, by the way, but I think this was a mistake made just because the helper returned CommandLineSourceFile.",0,0.5
 "By changing the root helper I prevented the AnalyzerConfigPaths from having to allocate an extra dictionary to do a Select, but I also had to convert paths into CommandLineSourceFiles for all the places that did take them.",0,0.5
 "Overall, garbage should be reduced going forward and it should prevent us making mistakes like we did in the past.",0,0.5
 "We don't need to lock for the happy case where we have the value cached, the worst that can happen in the other case is that we retrieve/store the same value twice if two threads are racing:",0,0.5
-Good catch. I'll tag them so they can take a look. Worst case we can just change the name back.,0,0.5
+Good catch. I'll tag them so they can take a look. Worst case we can just change the name back,0,0.5
 "This is almost certainly not the right place for this comment, but sorry: It seems like an incredibly small and simple change to review and merge! And it seems like such a no-brainer... most (99%+) programmers write their code starting at the top with the first line, not at the bottom with the last line... so covering up stuff you've just written, above where you're currently writing, seems like the wrong thing (to 99%+ of users).",1,0.5
-I'm strongly concerned with the memory safety of this code.,0,0.5
+I'm strongly concerned with the memory safety of this code,0,0.5
 "First of all you forgot to include the 0 byte in your buffer size calculation. I'm not trying to diss you here, rather this simply shows how such things are best abstracted away behind safer container classes. Even if the #code was 12 bytes large, it would fail the moment anyone touches the code and the reviewer forgets to re-check the correctness of the buffer size.",1,0.5
 "Additionally #code can theoretically return values as large as 2^16-1, resulting in a buffer size of 14!",0,0.5
 "MSVC's small string optimization (SSO) is unfortunately among the worst of all C++ stdlib implementations. But regardless its 15 byte buffer is plenty enough for both #code and #code, and allows you to use the regular #code function without incurring any allocations.",1,0.5
@@ -1895,16 +1897,16 @@ I'm strongly concerned with the memory safety of this code.,0,0.5
 "Based on the doc, the helper type only guarantee _instance to be GC ineligible after #code is called at the end of current method, right? It can still get GC'd before then, unless #code is inlined",0,0.5
 "not related to this PR, but to the code above: we don't need to clear the buffer before passing it to #code as #code ensures that it's going to populate its entire content. Even if there is garbage inside it, #code is going to overwrite it with whatever data it reads from the stream.",0,0.5
 "@github Thanks for taking a look, appreciate it! 😊",0,0.5
-There are mainly two differences I'm seeing in all of them:,0,0.5
+There are mainly two differences I'm seeing in all of them,0,0.5
 "- One less conditional branch in the ""fast"" version",0,0.5
-#NAME?,0,0.5
-Consider the first example:,0,0.5
+#NAME,0,0.5
+Consider the first example,0,0.5
 "The ""fast"" version has a single branch just for the #code check, then it simply does a compare with the method table pointer and sets the flag, whereas the other handles each condition separately 🤔",0,0.5
 "The worst offender would be the second example though, where the #code checks seem completely redundant, but as mentioned above I guess we'll just have to wait for the runtime to support the #code prefix for that (and that seems like a separate issue as well).",1,0.5
 "the counter name says ""pause time"", the API says ""GC duration"". for BGCs, these 2 are very different. the time between BGC start and end could be long but only a small portion of it is paused.",0,0.5
 "Worst case scenario, your app is in the middle of a deployment and you got the wrong contents, the likely outcome is that your app will crash and the user will have to reload (this problem is orthogonal to what we are trying here).",0,0.5
 "If you want to do this validation, then do it over the cached data the first time you load from cache and ""repair"" purge the entry from the dll once you detect that scenario.",0,0.5
-The total regression across the 200K methods is 269 bytes. Looked a few of the worst cases and don't see anything that can easily be addressed.,0,0.5
+The total regression across the 200K methods is 269 bytes. Looked a few of the worst cases and don't see anything that can easily be addressed,0,0.5
 "One somewhat related thing I spotted in #code is that when we move a non-loop block out of an inner loops, we may also move it out of the enclosing loop that it belongs to, and so we end up with messy layout in the outer loop. Note the ""return; always; return"" flow in the after picture below when we move BB08. Seems like we ought to be willing to put the block into the proper loop scope, even if there's no ""cheap"" placement there (that is, even if we have to add flow to branch around it... presumably one of the blocks has a branch targets outside proper loop, and we can reverse that branch to make room.",0,0.5
 (or perhaps the issue is that we don't recognize the full extent of the BB02 loop because it has multiple back edges...),0,0.5
 "The upshot of this is that we create an ""island"" block that is only ever jumped to and from (#code)",0,0.5
@@ -1941,76 +1943,76 @@ Full benchmark app: https://github.com/GrabYourPitchforks/ConsoleApplicationBenc
 "Don't read too deeply into the benchmark showing that the new #code logic consistently outperforms the original logic. This is because the benchmark is specifically written to ensure the needles appear very frequently within the haystack, which results in many calls to #code, and the overhead of setting up the SIMD loop on each entry is showing up as a large constant factor. Ignore this for now, as the really important takeaway is the worst-case algorithmic complexity as discussed in the previous paragraph.",0,0.5
 "@github what are your thoughts about including an app context switch (default to the new behavior)? If there is a customer broken by this, they would still be able to receive the other fixes in the 6.0.2 patch. There is no need for a switch in main/7.0 as that is a voluntary update.",0,0.5
 "Worst case, nobody uses it (I suspect nobody will)",0,0.5
-This seems sensible (conservative/safe to return the worst case state).,0,0.5
-I took a note in [https://github.com/dotnet/csharplang/issues/2201](https://github.com/dotnet/csharplang/issues/2201) to let LDM know.,0,0.5
+This seems sensible (conservative/safe to return the worst case state),0,0.5
+I took a note in [https://github.com/dotnet/csharplang/issues/2201](https://github.com/dotnet/csharplang/issues/2201) to let LDM know,0,0.5
 In reply to: [288212991](https://github.com/dotnet/roslyn/pull/35955#discussion_r288212991) [](ancestors = 288212991),0,0.5
-Where can we get a concise description of where TemporaryArray<T> is believed to be better than our traditional builder?,0,0.5
-@github it should always be better when the array will have to store 4 or less items.  This is for two reasons:,0,0.5
+Where can we get a concise description of where TemporaryArray<T> is believed to be better than our traditional builder,0,0.5
+@github it should always be better when the array will have to store 4 or less items.  This is for two reasons,0,0.5
 "1. the values are just stored on the stack, and no part of the TempArray will hit the heap.",0,0.5
 "2. there is no contention/garbage possibility around pooling.   this is because nothing is pulled (or returned) to a pool until you hit 5 elements.  This avoids those costs, as well as the (real) garbage cost that arises with pooling when concurrent returns happen and one returned item it overwritten by another returned item.",0,0.5
-You can practically think about it as if this gives you a small stackalloc'ed scratch area for lots of small-collection scenarios.  Only once you go past that scratch area do you have the same perf costs that you'd have today with normal ArrayBuilder.,0,0.5
-The [documentation](https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.getfunctionpointerfordelegate) for #code says:,0,0.5
-You must manually keep the delegate from being collected by the garbage collector from managed code. The garbage collector does not track references to unmanaged code.,0,0.5
+You can practically think about it as if this gives you a small stackalloc'ed scratch area for lots of small-collection scenarios.  Only once you go past that scratch area do you have the same perf costs that you'd have today with normal ArrayBuilder,0,0.5
+The [documentation](https://docs.microsoft.com/dotnet/api/system.runtime.interopservices.marshal.getfunctionpointerfordelegate) for #code says,0,0.5
+You must manually keep the delegate from being collected by the garbage collector from managed code. The garbage collector does not track references to unmanaged code,0,0.5
 "This is a Mono-specific codepath, so do different rules apply?",0,0.5
-I think it would be better to have a #code method on Compilation to break these cycles and allow things to be garbage collected.,0,0.5
+I think it would be better to have a #code method on Compilation to break these cycles and allow things to be garbage collected,0,0.5
 "Do you mean a conforming libc implementation isn't supposed to change the values in response to these functions, or do you mean these functions aren't recommended for use but if someone uses them the values may be changed?",0,0.5
-Sorry for being unclear. The latter.,0,0.5
-You can call these functions to change the value. This means you have the capability to change user (e.g. you're #code).,0,0.5
-It's best to call them from apps that are in tight control of their resources to limit security issues due to leaking resources of the privileged user.,0,0.5
+Sorry for being unclear. The latter,0,0.5
+You can call these functions to change the value. This means you have the capability to change user (e.g. you're #code),0,0.5
+It's best to call them from apps that are in tight control of their resources to limit security issues due to leaking resources of the privileged user,0,0.5
 "I'm not aware of apps that do this besides those specifically meant to change user (like #code, #code). That is the only thing they do.",0,0.5
-That's why I seriously discourage doing this in a .NET app.,0,0.5
+That's why I seriously discourage doing this in a .NET app,0,0.5
 "We could, if it makes a difference, avoid caching for #code (#code), since that is the most expected privileged user (which can use these calls).",0,0.5
 "IMO, #code is similar to #code: They both assume that the app can only ever have a single window.",0,0.5
 "This is fine (and convenient) for the majority of apps, but it is also a trap for the minority of developers who build multi-window apps. The worst scenario is when that developer takes a dependency on a library that uses these APIs.",0,0.5
 "Based on that, I think that:",0,0.5
 "- This API should never be used by libraries (including MAUI itself and the toolkit). An idea would even be to put something like #code, add the #code attribute to at least warn MAUI devs.",0,0.5
 "- We should move this singleton #code to a place that has a name that says ""Use this only if you are sure that this code will only be used in single window apps"" (something more explicit than a comment in the documentation that most devs will not read).",0,0.5
-Won't this double the garbage since we have to make the byte[] then copy it into a new byte[] inside ImmutableArray?  I think we used byte[] (even though it's mutable) to avoid that.,0,0.5
+Won't this double the garbage since we have to make the byte[] then copy it into a new byte[] inside ImmutableArray?  I think we used byte[] (even though it's mutable) to avoid that,0,0.5
 "Would it be possible to add target namespace, target folder, and api client class name parameters to the tool?",0,0.5
 "That sounds like additional customization users could do based on the incredibly poor ""documentation"" in <https://github.com/dotnet/aspnetcore/blob/main/src/Tools/Extensions.ApiDescription.Client/src/build/Microsoft.Extensions.ApiDescription.Client.props>. I would recommend adjusting the defaults to your preferences in the Microsoft.OpenApi.Kiota.ApiDescription.Client package and adding a bit more information for users over complicating the tool w/ lots of new options. Editing the updated project file isn't that big a deal.",1,0.5
-Why is the Option for CodeGenerator not using a generic type to pass the enum and leave the parsing to system.command line?,0,0.5
+Why is the Option for CodeGenerator not using a generic type to pass the enum and leave the parsing to system.command line,0,0.5
 "I don't remember the full history. @github made the most recent changes to the tool, @github wrote it, and @github did the VS side of things and designed the service that provides some of the versioning. @github may also have context.",0,0.5
 "@github Seriously dude, Rome wasn't built in a day. We're working on it, one step at a time. We're tracking MRU tab switching over in #973, so please have that discussion in that thread.",1,0.5
 6.3.1 Country Name,0,0.5
 "A value of the countryName attribute type specifies a country. When used as a component of a directory name, it identifies the country in which the named object is physically located or with which it is associated in some other important way.",0,0.5
-An attribute value for country name is a string chosen from ISO 3166-1 alpha-2.,0,0.5
-https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 looks like these are always two-letter uppercase pairs.,0,0.5
-Should we:,0,0.5
+An attribute value for country name is a string chosen from ISO 3166-1 alpha-2,0,0.5
+https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 looks like these are always two-letter uppercase pairs,0,0.5
+Should we,0,0.5
 * Reject anything that isn't [A-Z][A-Z],0,0.5
 * Normalize [a-z] to [A-Z] and reject anything that isn't [A-Za-z][A-Za-z],0,0.5
 "We certainly shouldn't embed the knowledge of ""assigned"" vs ""available"", but it feels like we can be guiding and flexible by rejecting digits and punctuation.",0,0.5
 "We can add that later perhaps. For now, we probably shouldn't crash the process since the worst outcome of missing a case here is fewer warnings.",0,0.5
 ---,0,0.5
 In reply to: [210390086](https://github.com/dotnet/roslyn/pull/29317#discussion_r210390086) [](ancestors = 210390086),0,0.5
-Actually the right thing to do here is to just remove the whole #code section and simply never set #code to #code and let the garbage collector do its thing.,0,0.5
+Actually the right thing to do here is to just remove the whole #code section and simply never set #code to #code and let the garbage collector do its thing,0,0.5
 "If you find these without a good workaround, we would like to know.",0,0.5
 "Don't worry, you will ;) .. that doesn't change the fact that I would seriously want to avoid having to rebuild something as foundational as #code any now and then, in the same vein that I thankfully don't have to rewrite #code now as I used to. :D",0,0.5
 "I think reflection in the tests is fine if you get good benefit and don't have another option. Nobody will break it except us - they'll discover it in CI if they do - then they can fix it or worst case delete the test, which leaves us no worse off.",0,0.5
-You could create a draft PR pointing to a build of this package and let the public CI do it's job. That shouldn't be too hard and could instill some confidence prior to merging this change.,0,0.5
-As part of this exercise I downloaded the DI package from this PR (postfixed with -ci). But it's not straightforward to test the package against aspnetcore CI since they also need the package to point to a nuget source somewhere the CI can access.,0,0.5
+You could create a draft PR pointing to a build of this package and let the public CI do it's job. That shouldn't be too hard and could instill some confidence prior to merging this change,0,0.5
+As part of this exercise I downloaded the DI package from this PR (postfixed with -ci). But it's not straightforward to test the package against aspnetcore CI since they also need the package to point to a nuget source somewhere the CI can access,0,0.5
 "Testing the DI package against all aspnetcore projects locally is a bit of a hassle too. I'm working with @github on this and perhaps worst case we could merge this, and test off the published package from merge, and if problems occur then revert accordingly.",0,0.5
 "I talked this over with the team and wanted to recommend a different approach. Most of this is going to be pretty obvious, but just bear with me while I think out loud for a minute.",0,0.5
-It appears that this hash code is being appended only when working with a default namespace. Which makes sense - keeping assemblies separate for different namespaces. The hash code is meant to be a predictable and persistent way to keep namespaces separated without having to append an entire namespace string in the assembly name which could be ugly at best and could run into more impactful issues at worst.,0,0.5
+It appears that this hash code is being appended only when working with a default namespace. Which makes sense - keeping assemblies separate for different namespaces. The hash code is meant to be a predictable and persistent way to keep namespaces separated without having to append an entire namespace string in the assembly name which could be ugly at best and could run into more impactful issues at worst,0,0.5
 "However, the original implementation fell into the trap of using String.GetHashCode() which was never meant to be persistent. In fact, it is not consistent across .Net Core and .Net 4.8. It isn't even consistent across 32 and 64-bit implementations of 4.8. String.GetHashCode() kind of worked by accident here, but was not really ever appropriate for the function it is performing here.",0,0.5
-Another thing to note is that generated assemblies do not really share between 4.8 and .Net Core due to netstandard.dll. So maintaining some resemblance with either 32-bit or 64-bit .Net 4.8 isn't much of a concern here.,0,0.5
+Another thing to note is that generated assemblies do not really share between 4.8 and .Net Core due to netstandard.dll. So maintaining some resemblance with either 32-bit or 64-bit .Net 4.8 isn't much of a concern here,0,0.5
 "So there is a bit of a ""green field"" opportunity to get this right this time. Criteria to note: We want something that produces a repeatable, persistent hash. The hash should be of reasonable length to avoid collision, but it is not required to be exactly 32-bits. Also, since this is not a hot code path where every bit of performance counts, we don't need to worry about being super fast. Finally, we're using this hash for naming purposes, not cryptographic purposes.",0,0.5
 "GetHashCode() meets all those criteria except for the most important - it's obviously not persistent. But rather than re-inventing an old wheel just because it feels familiar (although, this new wheel will not actually bring compatibility with the old cart)... lets use a tool that is proven and easily accessible. Use a truncated SHA512 hash. You could truncate to 32-bits as done previously. Or maybe use Span/Guid to truncate and get 128-bits with nice formatting?",0,0.5
-Perhaps @github has more thoughts?,0,0.5
+Perhaps @github has more thoughts,0,0.5
 "Regardless, I believe you'll also want to change SGen to match this change as well. https://github.com/dotnet/runtime/blob/master/src/libraries/Microsoft.XmlSerializer.Generator/src/Sgen.cs#L523",0,0.5
-We have a manual tests project for Console as a worst case; would this be caught there?,0,0.5
+We have a manual tests project for Console as a worst case; would this be caught there,0,0.5
 "In theory yes, because after running each test the user is asked to press #code and when pressing #code the app was printing #code instead of #code:",0,0.5
-. image](ht.,0,0.5
-But to be 100% sure I've added a new test:,0,0.5
-Any way to add a test?,0,0.5
-I currently don't have a better idea than extending the manual tests. I hope that when I get more familiar with #code I am going to be able to automate it.,0,0.5
-@github could you elaborate on why the Arm64 implementation can't basically be a 1-to-1 port of the x86/x64 logic?,0,0.5
+. image](ht,0,0.5
+But to be 100% sure I've added a new test,0,0.5
+Any way to add a test,0,0.5
+I currently don't have a better idea than extending the manual tests. I hope that when I get more familiar with #code I am going to be able to automate it,0,0.5
+@github could you elaborate on why the Arm64 implementation can't basically be a 1-to-1 port of the x86/x64 logic,0,0.5
 "There isn't really anything in #code that isn't in #code and #code is pretty trivial (there is nothing there that isn't a simple translation over - #code to #code, #code to #code just need to double check edge case handling, #code to #code + #code + #code in the worst case).",0,0.5
 "I do understand using #code might be even faster, but it'd be better to start with something that gives us the initial gains then have nothing at all.",0,0.5
 "GCHandle.Alloc is not only keeping the array pinned, it's also keeping it rooted, whereas the GC.Allocate* calls are just creating pinned arrays but not keeping them rooted.  In all of these uses where we've replaced the GCHandle.Alloc calls, have we proved to ourselves sufficiently that the array won't become garbage in the interim?",0,0.5
 "Any concerns here that if two threads are trying to compute the new SemanticModel that even though one CompareExchange is the ""winner"" and one is the ""loser"" that the loser won't use the winner's semantic model if it's available?",0,0.5
 "I don't think the behaviour for conhost is right. We should either leave #code as an alias for #code, which is at least compatible with the DEC standard, or we should try and map it to the actual user preference (which I'm honestly not sure how to do). Worst case we could possibly map it to blinking legacy, which I think is the system default. But as it stands, it looks like you're going to get non-blinking legacy, which is neither one thing nor the other.",0,0.5
-Edit: Sorry this is essentially a long-winded dup of DHowett's comment.,0,0.5
-Would be interesting to profile that -- interpolated strings are *supposed* to be getting lots of perf love.,0,0.5
+Edit: Sorry this is essentially a long-winded dup of DHowett's comment,0,0.5
+Would be interesting to profile that -- interpolated strings are *supposed* to be getting lots of perf love,0,0.5
 "Fortunately, someone used Benchmark.net: https://blog.ladeak.net/posts/string-interpolation-stringbuilder",0,0.5
 "String interpolation isn't the worst, but it's not the best.  Using #code is the 2nd fastest.",1,0.5
 "For now, I'll add a new method which uses #code.  (Pity #code only takes up to 4 parameters!  5 would have been best.)",0,0.5
@@ -2027,41 +2029,41 @@ better to heap allocate #code and free it from #code,0,0.5
 "* For other code paths, like #code this indicates we can't emit this without some corresponding #code check being in place (we don't currently support such a check, so we treat it as #code",0,0.5
 suggestController.ts is entry point of changes,0,0.5
 "I did not implemented fixed storage for small overtypes since calling ITextModel.getValueInRange() is producing garbage anyway. So, simply storing. Restricted by 1000000 bytes as was suggested.",0,0.5
-Made the retrieval of stored text deferred until needed in the SelectionBasedVariableResolver.,0,0.5
+Made the retrieval of stored text deferred until needed in the SelectionBasedVariableResolver,0,0.5
 off topic,0,0.5
 "I noticed that SuggestWidget.onDidHide gets called constantly when typing, even when SuggestWidget.onDidShow has not been called before and the widget is not active. Perhaps this should be removed for performance.",0,0.5
-does not #code have linear complexity in the worst case?,0,0.5
-I think you should seriously consider this -- eg the loop and its clone may have common hoistables.,0,0.5
+does not #code have linear complexity in the worst case,0,0.5
+I think you should seriously consider this -- eg the loop and its clone may have common hoistables,0,0.5
 "this will cause an extra object allocation for every occurrence. we use this on every hover, and do not want to increase the amount of garbage we create.",0,0.5
 "So this makes me think that we'll be redoing a lot of inferences - for a given inference set, we'll infer from each of the inner properties to their matching contextual type, then we'll do the outer inference for the object as a whole, which, in so doing, will redo these inferences again",0,0.5
 "I think ([see my comment here](https://github.com/microsoft/TypeScript/pull/48538#issuecomment-1088157524)) that that's why this is only done when we're about to fix (which are cases that are broken today). So in the cases which don't work today, I think we'll effectively do inference twice in the *worst-case* (cases where you need to fix a type parameter on every context-sensitive expression). Otherwise, it should be the same amount of inference as before, the only new work is collecting the context-sensitive inner expressions).",0,0.5
 SignalR gets the headers by calling #code method,0,0.5
 "That's the wrong extension point, users should be passing headers via the new option. If they want to do special things in their custom http client then they can do that in send.",1,0.5
-will do. I just wanted quick check from you guys whether this is even okay to do.,0,0.5
+will do. I just wanted quick check from you guys whether this is even okay to do,0,0.5
 "is checksum and the embedded blob thing not there okay? I think I am using encoding wrong though. since I am getting TextReader, it should be already normalized to certain encoding, the given encoding should be just passed along like StringText.From(string, encoding), and not actually used anywhere else.",0,0.5
 "Am I crazy, or could PipeOptions be shared?",1,0.5
-We should link to the issue both places we do the crazy private reflection.,1,0.5
+We should link to the issue both places we do the crazy private reflection,1,0.5
 "I have no horse in this race, but the comments as-is are definitely wrong with regard to the code 😄",1,0.5
 "It seems wrong to mark these as non-nullable. Any non-internal user of this API will leave these null, right?",0,0.5
-@github I have no idea what's wrong with Linux or how to fix it!,0,0.5
-It looks like #code could be #code and then we will not enter this conditional.  That seems wrong.,0,0.5
-why was the previous code wrong?,0,0.5
+@github I have no idea what's wrong with Linux or how to fix it,0,0.5
+It looks like #code could be #code and then we will not enter this conditional.  That seems wrong,0,0.5
+why was the previous code wrong,0,0.5
 "IVariableDeclarationStatement (1 declarations) (OperationKind.VariableDeclarationStatement) (Syntax: 'i = 0') [](start = 6, length = 109)",0,0.5
 "It is not clear why did we lose the statement, feels wrong. #Closed",1,0.5
 "@github is it ok for this to go into preview8? It's currently targetting the wrong branch. I will take care of doing whatever it needs to get done here, but I'll have to get the change through ask mode to get it in preview8.",0,0.5
 Just let me know if this is good for preview8 and I will take care of the rest,0,0.5
 "Hmm, I had thought I tried that syntax and it hadn't worked, but I probably just typed something wrong. I'll add a couple of tests for this, and subparts.",0,0.5
 In reply to: [144358694](https://github.com/dotnet/roslyn/pull/22630#discussion_r144358694) [](ancestors = 144358694),0,0.5
-Same comment: We should be testing to make sure that appropriate exceptions are thrown on wrong-language invocations.,0,0.5
+Same comment: We should be testing to make sure that appropriate exceptions are thrown on wrong-language invocations,0,0.5
 Please open an issue to add this.  #Closed,0,0.5
-I got this wrong. Awaits are indeed allowed inside finally. So should async usings.,0,0.5
+I got this wrong. Awaits are indeed allowed inside finally. So should async usings,0,0.5
 In reply to: [161408348](https://github.com/dotnet/roslyn/pull/23961#discussion_r161408348) [](ancestors = 161408348),0,0.5
 It wasn't wrong before. See http://whatis.techtarget.com/definition/Fibonacci-sequence,0,0.5
 "@github, I changed, but now it says:",0,0.5
 "Maybe I changed it from right to wrong, or changed the wrong file, I don't know.",0,0.5
 "Weird, it looks like everything is getting skipped on the Fedora queue, though maybe I'm reading the tests tab wrong? For fedora I see only successful work items, whereas for for other queues I see work items & individual tests. @github is there a way to grab the testresults.xml files from the successful Fedora work items?",0,0.5
 "Honestly, using the callback version should be default and if you don't want to spend any effort, you shouldn't spend effort thinking whether you can afford to *not* use it. I've seen at least 3 different code fix crashes because the wrong overload was used here.",0,0.5
-because i'm dumb.  #fixed.,0,0.5
+because i'm dumb.  #fixed,0,0.5
 "node.Type [](start = 93, length = 9)",0,0.5
 Wouldn't this be a wrong type for the call when ``#code`` is nullable? It feels like we should use method's return type here and then make nullable out of this call if needed. #Resolved,0,0.5
 "I made the change in a rush, thinking I was checking the parent of #code. CI proves me wrong.",0,0.5
@@ -2070,53 +2072,53 @@ Wouldn't this be a wrong type for the call when ``#code`` is nullable? It feels 
 "Also, ternary/conditional expressions that are #code might have an issue. #Pending",0,0.5
 "I tested the Android changes by rebasing against your branch. CoreCLR build succeeded (native and managed components), no more errors about crossgen2. 👍  Libraries build continues to succeed (native and managed components).",0,0.5
 "However, in installer build, it has progressed to fully build native (with correct RID) and managed components (with wrong RID), thereby packaging step fails because of the wrong RID was picked up during the ngen and perfmap generation steps:",0,0.5
-Can we do some unification so RID is resolved consistently from a single source of truth for ngen/perfmap steps as well? Maybe not part of this PR but if it is now feasible I think it would smooth things up for new platforms if resolving RID in multiple places is avoided.,0,0.5
+Can we do some unification so RID is resolved consistently from a single source of truth for ngen/perfmap steps as well? Maybe not part of this PR but if it is now feasible I think it would smooth things up for new platforms if resolving RID in multiple places is avoided,0,0.5
 "some modifiers cause us to bail out of local function parsing and try member parsing, but generally we reject bad local function modifiers here:",0,0.5
 "(edit: I had the wrong line number before, sorry)",0,0.5
 https://github.com/dotnet/roslyn/blob/9a88cd45a5493b682c0e7812559f7e07b63ab866/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs#L8455,0,0.5
 "IEquatable<IntPtr> [](start = 27, length = 18)",0,0.5
 "Given that we have a custom code to match the type, I think we should cover negative cases as well, i.e.",0,0.5
 "- The name match, but containing namespace name doesn't",0,0.5
-#NAME?,0,0.5
+#NAME,0,0.5
 - IEquatable is a nested type and container's name is and is not System,0,0.5
-#NAME?,0,0.5
-#NAME?,0,0.5
+#NAME,0,0.5
+#NAME,0,0.5
 - IEquatable has arity 2,0,0.5
 "- IEquatable is constructed with a ""wrong"" argument",0,0.5
-#NAME?,0,0.5
-#NAME?,0,0.5
+#NAME,0,0.5
+#NAME,0,0.5
 - Etc. #Closed,0,0.5
-That can only occur via misuse of a public API.,0,0.5
+That can only occur via misuse of a public API,0,0.5
 "The public API explicitly caters to this, namely the distinction between ""Project.ProjectReferences"" vs. ""Project.AllProjectReferences"". I don't now if this is a useful feature anymore (at one point MSBuildWorkspace used it I think) and sure wish it didn't exist, but I'd say if we're going to change that let's change that specific thing in our 16.7 feature branch just to get that behavior change in early in a cycle so we can get time to find out what we broke. The rest of this PR is at least changing things we didn't _try_ to support. :smile:",0,0.5
 "Without this the invariant validation fails, so either the validation is wrong or the _projectIds are wrong.",0,0.5
-I dug a bit further: so the assumption in the existing implementation (at least at one point) was that the dependency graph isn't told about project references to non-existent projects. Then during project addition we attempt to fix those up:,0,0.5
+I dug a bit further: so the assumption in the existing implementation (at least at one point) was that the dependency graph isn't told about project references to non-existent projects. Then during project addition we attempt to fix those up,0,0.5
 https://github.com/dotnet/roslyn/blob/master/src/Workspaces/Core/Portable/Workspace/Solution/SolutionState.cs#L429-L441,0,0.5
 "So whatever calls this method the references that go into the ProjectDependencyGraph, since it's fixed up in that AddProject code I linked to above. Note that adding it to the main _projectIds collection can also have other side effects: calls asking for the topologically sorted project IDs would then return them which shouldn't be happening.",0,0.5
-Yes. Is something wrong with it? Did I miss something?,0,0.5
-Yeah - that's a non minimal edit and fixes another (un-filed) issue where the memory service would also use the wrong editor position.,0,0.5
-Is the order of these very important? Will there be trouble if someone inserts one in the wrong spot in the future or reorders them?,0,0.5
-The path seems wrong. It should be #code instead of #code.,0,0.5
+Yes. Is something wrong with it? Did I miss something,0,0.5
+Yeah - that's a non minimal edit and fixes another (un-filed) issue where the memory service would also use the wrong editor position,0,0.5
+Is the order of these very important? Will there be trouble if someone inserts one in the wrong spot in the future or reorders them,0,0.5
+The path seems wrong. It should be #code instead of #code,0,0.5
 "@github great catch, if I'm not mistaken, I think pinned composite ids is also the wrong choice, we only care about visible ids when dragging in dropping. looks good?",0,0.5
 "This fixes another potential problem where things can wrong in the original code. For example, the original code can get into infinite loop with corrupted data here. We will just exit the loop now.",0,0.5
-This is not impossible because we know which extension has triggered the open-command and we can always install the 'extra open args' for a specific extension only.,0,0.5
+This is not impossible because we know which extension has triggered the open-command and we can always install the 'extra open args' for a specific extension only,0,0.5
 "That will not help for the case which imho is also the most likely one: you see a tree from 1 extension and interact with it multiple times with multiple items in short time frame. Chances are high that if the opening takes long, the context we set is always wrong.",0,0.5
 "This one is technically wrong. It suggests that pressing this chord _right now_ will activate this action, but what we're providing is more informative than actionable.",0,0.5
-I think for this one we should _not_ use AcceleratorKey and instead remove the Raw property on the border/textblock that contains the binding.,0,0.5
+I think for this one we should _not_ use AcceleratorKey and instead remove the Raw property on the border/textblock that contains the binding,0,0.5
 "The grid/splitview can't modify priority, they only read the value. The views themselves set it. The user of the grid (EditorPart) would coordinate across its views and set their priorities accordingly.",0,0.5
-But on second thought maybe that's too crazy. Let's tackle both issues individually and start with https://github.com/microsoft/vscode/issues/70083 first.,0,0.5
+But on second thought maybe that's too crazy. Let's tackle both issues individually and start with https://github.com/microsoft/vscode/issues/70083 first,0,0.5
 "The maximized state isn't preserved across layout calls. If we fix it, we don't want to change the default spltiview behavior, but add/modify an option. What if we have a [different type for #code](https://github.com/microsoft/vscode/blob/7b6c1065c76708d146844154c8a33906f06dce0b/src/vs/base/browser/ui/splitview/splitview.ts/#L167-L173)? Like:",0,0.5
 "That way, we can preserve a maximized view's state across #code calls. We can even have tests for this. The problem is what happens when the user resizes the splitview until it reaches the sum of all minimum sizes: at that point no view will be maximized any more. So, growing the splitview from then on would make it grow all views proportionally. This is why using layout priorities would be benefitial here. But we can also live with that behavior.",0,0.5
 "As for https://github.com/microsoft/vscode/issues/137865, the grid/splitview already supports sizing options when adding views. The [EditorPart just mostly uses #code](https://github.com/microsoft/vscode/blob/7b6c1065c76708d146844154c8a33906f06dce0b/src/vs/workbench/browser/parts/editor/editorPart.ts/#L529), which causes today's behavior. I would first try to fix the issue by using a different sizing option here.",0,0.5
 "@github Sincerely i dont know. The last time i tried to ""play"" with task and Navigation in UWP i gave up, i was getting a lot of random MemoryAccess violation that drove me crazy.... (expecially when navigation fast between pages).",0,0.5
 "It would be cool to have Tasks here like in iOS & Android but i'm a bit ""scared"", given my past on the subject.",0,0.5
 "Buuut, i'm a beginner in UWP so maybe i'm terribly wrong :)",0,0.5
-I suspect it's rather unlikely that #code is true.,0,0.5
-So how about we write it as if it was wrong most of the time:,0,0.5
+I suspect it's rather unlikely that #code is true,0,0.5
+So how about we write it as if it was wrong most of the time,0,0.5
 Personally I'd shorten these things to,0,0.5
 "The benefits as I personally, subjectivelly perceive them:",0,0.5
-* Easier to read.,0,0.5
-* It compiles to what GCC/Clang would produce. MSVC always needs a bit of handholding when it comes to booleans.,0,0.5
-* And a longer one...,0,0.5
+* Easier to read,0,0.5
+* It compiles to what GCC/Clang would produce. MSVC always needs a bit of handholding when it comes to booleans,0,0.5
+* And a longer one,0,0.5
 "CPUs appear to be really fast nowadays, but they're actually often just as dumb as they used to be. One of the problems is that the ""predictor"" for branches has a limited size. While an important branch like this has literally 0 performance impact on this code and is absolutely fine, it might displace actually important branches out of the limited branch predictor cache.",0,0.5
 "For instance I have a PR open which simply removes #code and improves performance by ~5% on my CPU. This is really weird actually, because if you benchmark #code in a small benchmark project you'll find that it's super fast. And it's only iterated about ~100/sec! Still... it's mere presence has a negative impact, despite being fast itself. CPUs are dumb.",0,0.5
 That said I wouldn't mind merging it as is. 😄,0,0.5
@@ -2132,19 +2134,19 @@ That said I wouldn't mind merging it as is. 😄,0,0.5
 "There's a fundamental problem with this idea: while it should be fine for on-device apps, this will break the Designer, as the Designer does not (yet?) create or use typemap files.",0,0.5
 "I suspect that's why the [#code test)](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4441039&view=ms.vss-test-web.build-test-results-tab&runId=18707974&resultId=100298&paneView=debug) is showing only Java names, not managed names:",0,0.5
 And the [#code test](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=4441039&view=ms.vss-test-web.build-test-results-tab&runId=18707974&resultId=100124&paneView=debug),0,0.5
-Unrelated to this PR but wtf. @github @github can we fix this?,1,0.5
+Unrelated to this PR but wtf. @github @github can we fix this,1,0.5
 "UI code depending on synchronous parsing makes me sad.   might not be terrible to do this async, and pop in the checkmark when we know... (but that would add a lot of async compexity to these codepaths).",0,0.5
 hello vs code wakeup and merge this. your stupid ctrl f behavior is so annoying,1,0.5
 *Draft release notes*,0,0.5
 "No terrible hurry on this while this PR is still under active revision, but if I understand correctly, I think once this PR is eventually merged it will enable OpenJDK 11 compatibility for user builds? If that's correct, then it might be appropriate to add release note to #code as part of this PR.",0,0.5
-Here's a very rough first draft of one possible idea:,0,0.5
+Here's a very rough first draft of one possible idea,0,0.5
 "On the other hand, this PR itself might not need a release note, if for example the Visual Studio installer will be updated to provide OpenJDK 11 by default in the same release where OpenJDK 11 compatibility ships. In that case, the main topic in the release notes can be the new default OpenJDK version.",0,0.5
 "In either case, there will likely be some docs to update, such as: <https://docs.microsoft.com/xamarin/android/troubleshooting/questions/jdk9-errors>",0,0.5
 "@github: How insane would it be to build #code ""separately"" for the Android Designer, so that we can #code out this logic for on-device use but leave it in for the Designer?",0,0.5
 "Alternatively, What If™ we moved the logic into a new method, then *removed* that method via the linker when linking apps?",0,0.5
 Well at least I deterministically am terrible at spelling,0,0.5
-I'd disagree here: I think there's a beauty to the test classes being self contained. Otherwise we end up with insane inheritance hierarchies that only make what the code is doing _less_ clear. Duplicated code isn't bad; complexity is.,0,0.5
-I am curious though why each test has to call .Initialize()...?,0,0.5
+I'd disagree here: I think there's a beauty to the test classes being self contained. Otherwise we end up with insane inheritance hierarchies that only make what the code is doing _less_ clear. Duplicated code isn't bad; complexity is,0,0.5
+I am curious though why each test has to call .Initialize(),0,0.5
 "@github stupid question, does it run the tree targets all the time? i.e. it would not considered passed until the test passed on the three targets? if so i would keep it to two if we can.",0,0.5
 "I don't think the original issue was so terrible. You only ran into this case when you were contextually typed by a type with a string literal constituent to begin with. In practice, this is not frequently encountered.",0,0.5
 "However, @github, I think you'll like the the current implementation a lot better. We now only create a string literal type if the constituent types have a string literal type, not just if their content is equal.",0,0.5
@@ -2153,7 +2155,7 @@ I am curious though why each test has to call .Initialize()...?,0,0.5
 "@github I saw this was done for ObservableItemTemplateCollection for Windows, so I copied that. Mainly just for the dispatcher, but if we pass the view in, then we never have to worry about reaching out into the Application. or Device. worlds.",0,0.5
 "Not sure if this is going to do terrible things with lifetime and/or memory. If so, we can change and find another way.",0,0.5
 this seems like a terrible idea.  why not just compare to ``#code`` #Resolved,1,0.5
-Can we unify these codepaths?,0,0.5
+Can we unify these codepaths,0,0.5
 "~I tried, but I couldn't come up with a good solution. I tried:~",0,0.5
 1. ~Take a SyntaxNode from the method to remove from the candidates~,0,0.5
 "~This does not work, because in VB you need go to the parent of the declaration and call #code on it:~",0,0.5
@@ -2161,25 +2163,25 @@ Can we unify these codepaths?,0,0.5
 2. ~Take the IMethodSymbol of the candidate to remove~,0,0.5
 ~Now the whole method has degenerated and also the #code type needs a new property #code (making the type somewhat stupid having the properties #code and #code :dizzy_face:).~,0,0.5
 ~Both attempts complicate things and that's why I would prefer to keep the two code paths separated. But maybe you have another idea on how to solve this problem.~,0,0.5
-See 269a68c for how I solved it.,0,0.5
-holy crap. since this gets called on destruction please write a huge comment in here to say **DO NOT INTERACT WITH THE CONTROLCORE AFTER THIS LINE** because it could have gone into the background after the destructor!,0,0.5
-It's not terrible; it's not great.  I have no suggestions.,0,0.5
-Fortunately it isn't public API...,0,0.5
+See 269a68c for how I solved it,0,0.5
+holy crap. since this gets called on destruction please write a huge comment in here to say **DO NOT INTERACT WITH THE CONTROLCORE AFTER THIS LINE** because it could have gone into the background after the destructor,0,0.5
+It's not terrible; it's not great.  I have no suggestions,0,0.5
+Fortunately it isn't public API,0,0.5
 "I'm stupid, went to fast :/",1,0.5
 "Yeah there is an interesting push and pull in this sort of thing. You can make the syntax to disable things as gross as possible to disincentivize disabling, on the other hand you might accept that disabling things is a fact of life and it shouldn't look like an atrocity.",0,0.5
-This is a good example of what I was mentioning to @github as far as how I only fixed the easy 80-90% cases as the rest that require non-trivial rewrites will generate some amount of discussion on whether we feel some particular situation warrants an exception.,0,0.5
-My opinion is just make the change to satisfy the linter. While I see the argument for the 'define as close to usage as possible' it's not hard to use GoToDef occasionally vs adding gross comments.,0,0.5
+This is a good example of what I was mentioning to @github as far as how I only fixed the easy 80-90% cases as the rest that require non-trivial rewrites will generate some amount of discussion on whether we feel some particular situation warrants an exception,0,0.5
+My opinion is just make the change to satisfy the linter. While I see the argument for the 'define as close to usage as possible' it's not hard to use GoToDef occasionally vs adding gross comments,0,0.5
 "Your code is also missing one important point: you're only propagating the new direct references. If A -> B and C -> D, and I'm adding B -> C, then you need to get D added too. My first loop computes you need to include D, also accounting for the fact we might not know C's transitive references and thus instead need to propagate ""we don't know"".",0,0.5
 Ack.  That feeling when you realize you're an idiot :D,1,0.5
 item3 is a pretty terrible name.  it also seems incorrect given that Item3 looks to be a DeclarationExpressionSyntax.  Name tuple properties are a good thing :),0,0.5
 "Yeah, I need to figure out better wrapping. That said, they all look terrible.",0,0.5
 "The above one, the lambda-ness of it is getting insane. There are so many ({{({()})}}}) that I think it will lead to mistakes and issues more than separating out the method. You should prescribe a separate method if possible at this point.",1,0.5
-Base time running #code:,0,0.5
-Time running after adding this new test:,0,0.5
+Base time running #code,0,0.5
+Time running after adding this new test,0,0.5
 "@github I would consider keeping this test as #code considering that the test above, #code, which uses a similar code minus the insane amount of dictionary instances, is",0,0.5
-already signaled to run on #code.,0,0.5
+already signaled to run on #code,0,0.5
 "holy crap, this is what does the LRU magic",0,0.5
-* [ ] How are we lanning on dealing with the numerous TabView quirks in v2? Just ship it as-is and fix in post? Or manually adjust the styling now?,0,0.5
+* [ ] How are we lanning on dealing with the numerous TabView quirks in v2? Just ship it as-is and fix in post? Or manually adjust the styling now,0,0.5
 * [ ] EX the close button hover is weirdly wide,0,0.5
 * [ ] the tab text is bold,0,0.5
 "* [x] Icons throughout the app are still on the Segoe MDL2, not Segoe Fluent",0,0.5
@@ -2201,103 +2203,103 @@ gross,1,0.5
 "- After initial PR being closed, the bot keeps sending PRs, effectly spamming the repos. For example, these 5 PRs were sent to the same repo within 2 days [#1](https://github.com/996icu/996.ICU/pull/26073) [#2](https://github.com/996icu/996.ICU/pull/26074) [#3](https://github.com/996icu/996.ICU/pull/26075) [#4](https://github.com/996icu/996.ICU/pull/26076) [#5](https://github.com/996icu/996.ICU/pull/26077)",0,0.5
 "To save more time for the open-source community, we recommend the maintainers of VSCode to close this PR and ban this bot from further spamming.",0,0.5
 Ignore failure due to https://github.com/xamarin/maccore/issues/2440 (AKA I'm an idiot),1,0.5
-i am a stupid person. typescript is garbage. Bill should be fired.,1,0.5
+i am a stupid person. typescript is garbage. Bill should be fired,1,0.5
 Changed back for now and put all the gross casting code back,1,0.5
-Applies the technique from dotnet/runtime#35330 to IOQueue.,0,0.5
+Applies the technique from dotnet/runtime#35330 to IOQueue,0,0.5
 I was thinking about it too :D,0,0.5
-The other (and most probably a **very stupid**) idea I had was to try to have a scheduler that in the ctor would use reflection to access the internal field of ThreadPool that stores the work items in a #code:,0,0.5
+The other (and most probably a **very stupid**) idea I had was to try to have a scheduler that in the ctor would use reflection to access the internal field of ThreadPool that stores the work items in a #code,0,0.5
 and implement the #code method as a simple call to enqueue of this CQ,0,0.5
 "Again, this is a very dirty idea ;)",1,0.5
 The logging is _insane_; is any of that detail useful❔,0,0.5
 "I turned it on hoping it would be useful, but either it contains nothing for us or I don't know how to find the useful information in it. We should probably turn it off at this point.",0,0.5
-We discussed this with @github. It seems there it would be useful to have re-considering this parsing but not for now.,0,0.5
-Pity.  That parsing is truly terrible :)   I'll put it on my backburner to see if there's a way to improve things.,0,0.5
+We discussed this with @github. It seems there it would be useful to have re-considering this parsing but not for now,0,0.5
+Pity.  That parsing is truly terrible :)   I'll put it on my backburner to see if there's a way to improve things,0,0.5
 "stupid me, again",1,0.5
 "wait, we definitely can't put #code or #code's in here directly -",0,0.5
 "holy shit _what_, you can #code and it works? That's insane.",1,0.5
-I agree on [Sealed].,0,0.5
+I agree on [Sealed],0,0.5
 "I was tempted to make a less terrible version, but there are two other ""copies"" of PresentError in appkit.cs and I wasn't sure what's worse:",0,0.5
-#NAME?,1,0.5
-#NAME?,1,0.5
+#NAME,1,0.5
+#NAME,1,0.5
 "In either case, I can work on a XAMCORE_4_0 version for at least two, and do something (either match or be different) w\ this new one.",0,0.5
 "@github - This is intended to optimize lab runs where we need to run build-test several times with limited sets of steps (e.g. native component build takes place on a different machine than managed component build and the layout gets generated on yet another machine in the lab pipeline) and Bruce noticed that we're unnecessarily duplicating some steps in such scenario. You're right that removing crossgenning of framework from ""generatelayoutonly"" is a breaking change, I'll fix that. Frankly speaking, the command-line syntax of build-test is a terrible mess with its arbitrary combination of exclusive (skip***) and inclusive (***only) commands.",0,0.5
-Mono should change their formatter configuration if they don't want the includes sorted. Otherwise there's no way to enforce formatting.,0,0.5
+Mono should change their formatter configuration if they don't want the includes sorted. Otherwise there's no way to enforce formatting,0,0.5
 How do I do that?  I'm an .editorconfig noob,0,0.5
 Gross,1,0.5
 "No, because everything is terrible and on fire and also very very sad.",1,0.5
 "The comment at #code explains a bit of it - msbuild calls into these members really randomly, and one has to be extremely careful to not accidentally hit a recursion loop.",0,0.5
 "(I documented this a bit more, too)",0,0.5
 "omg, this order is terrible.",1,0.5
-Noob question - why is this task returning (vs ValueTask returning)?,0,0.5
+Noob question - why is this task returning (vs ValueTask returning),0,0.5
 "#code's #code is also deprecated, so not sure if it makes sense to rely on it (especially since we have the non-deprecated #code.",0,0.5
 I'm also very curious about why we're already letting #code through #code,0,0.5
-Makes sense to be worried about #code if it can be used to execute. What about being super restrictive like this? Allowing colors is really the only goal here.,0,0.5
+Makes sense to be worried about #code if it can be used to execute. What about being super restrictive like this? Allowing colors is really the only goal here,0,0.5
 "Hmm, I suspect that the ""proper"" way to do this is to add the address to the ""zero offset field map"". But then I happen to think that this kind of side maps are a terrible idea and that the it's best to keep this information in the IR, in special nodes - PTR_FLD and PTR_IDX.",0,0.5
 "I have checked how it works with ""zero offset field map"" and you are right, overall results are better.",0,0.5
 "#code has almost all logic that we need, we just not calling it sometimes.",0,0.5
-The only downside is that #code now cannot understand that it doesn't need a null check in cases like:,0,0.5
+The only downside is that #code now cannot understand that it doesn't need a null check in cases like,0,0.5
 "The first indirection is done on #code, the second on #code and after the change they have different VNs, so too hard for #code. Probably that behaviour is responsible for other uneccessary null checks, I will look for an exisitng issue tomorrow.",0,0.5
-When we had add we skipped it in #code:,0,0.5
+When we had add we skipped it in #code,0,0.5
 "It is almost 3am, but my brain says that #code should not affect VN of #code (because it is a pointer type, not a real value), but should affect #code node on top of it. Does it make sense?",0,0.5
 "Oh, I'm too stupid to read IL properly :wink: (realized that this was wrong when I come back in the office -- too late).",1,0.5
-Thanks. I'd liked the explicit version better anyway.,0,0.5
+Thanks. I'd liked the explicit version better anyway,0,0.5
 "@github, do you recall whether we still use these for anything or can they be safely removed? Context [here](https://github.com/dotnet/aspnetcore/blob/master/src/Razor/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngine.cs#L160)",0,0.5
 Hmmm you can validate to see if they're consumed at all in the Mvc 1_x / 2_x projects: https://github.com/dotnet/aspnetcore/tree/master/src/Razor/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X,0,0.5
 "@github, this was obsoleted around April 2019. Can we safely remove it now but do you think we should wait for another release? I'm not sure if this is something customers will be depending on.",0,0.5
 "Actually I think I was stupid for obsoleting this at all. I'd actually say it's probably worth ""unobsoleting"" it. There's still value.",1,0.5
-Cause I'm still a noob with Visual Studio code.,0,0.5
+Cause I'm still a noob with Visual Studio code,0,0.5
 "I'm not the most qualified to review this PR, but it does make sorta sense to me.",0,0.5
-I hope others find time to review it as well.,0,0.5
-Finally I'm not entirely happy with #code. The #code will always allocate on the heap which is slow in a non-GC language like C++.,0,0.5
-I convinced it would've been more ergonomic to call it directly in the loop and have it switch through the #code every time. Since #code is constant a modern CPU would have the easiest time of its life to predict the correct switch case.,0,0.5
+I hope others find time to review it as well,0,0.5
+Finally I'm not entirely happy with #code. The #code will always allocate on the heap which is slow in a non-GC language like C++,0,0.5
+I convinced it would've been more ergonomic to call it directly in the loop and have it switch through the #code every time. Since #code is constant a modern CPU would have the easiest time of its life to predict the correct switch case,0,0.5
 "I would also prefer if it was a little less alloc-happy... but we need to give Carlos a good suggestion then, @github. I think the C-style way of declaring the methods is probably too gross (though it would avoid this.) Could we pass some static refs to these functions so they're only allocated once? Or hold them in a map? Or would holding onto them be a waste of memory long term?",0,0.5
 "Native AssemblyLoadContext is not a native representation of the managed one, it just has a link to the managed, and can provide it via GetManagedAssemblyLoadContext",0,0.5
 "True, but for all intents and purposes #code-native has 1:1 relationship with #code-managed. The native one has a pointer to the managed one (and vice versa). Also all of the functionality of managed ALC is implemented (indirectly) in the native ALC (lot of this is hidden in the #code which is embeded in the native ALC - and yes - that name is TERRIBLE and has to go :-), but that's a different refactoring)",0,0.5
 "Yah, string enums don't merge across files, while you can make an interface that does (via module augmentation). Downside is you have to use _assignments_ to actually create the value side. Terrible, I know.",0,0.5
-I'm curious if aligned REP STOS measurably pays off (both for 16 and for 32 byte alignments).,0,0.5
+I'm curious if aligned REP STOS measurably pays off (both for 16 and for 32 byte alignments),0,0.5
 "I'm assuming it will be better than current, looking at Agner Fog instruction tables; for aligned Vector is definitely better, but I'd guess it hits instruction decoding costs when you have a large number of them + code size/icache.",0,0.5
 "For unaligned REP STOS looks terrible by comparison, whereas aligned to 32 bytes is same throughput as #code movs?",0,0.5
 "Thinking on the vector latency of 3 clocks; and perhaps same for #code; methods seem to start using the highest stack values first, whereas current am clearing the highest values last. Might it make sense to reverse the clearing order?",0,0.5
-Also would #code be happy with a negative count so it goes backwards also?,0,0.5
-This is really kinda gross. I think we need to have some discussion before making a change like this. I don't want to see us keep evolving our testing strategy without careful consideration.,1,0.5
-Again - does this need #code?  I'm terrible with the rules for lambdas.,1,0.5
+Also would #code be happy with a negative count so it goes backwards also,0,0.5
+This is really kinda gross. I think we need to have some discussion before making a change like this. I don't want to see us keep evolving our testing strategy without careful consideration,1,0.5
+Again - does this need #code?  I'm terrible with the rules for lambdas,1,0.5
 "How many strings are we talking about if we split them out. Unless it's insane, I'd recommend doing that and eliminating even having to worry about this.",0,0.5
-It will end up at about 4ish resources per construct we want to support.  Not something really problematic.,0,0.5
-Thanks @github and @github !,0,0.5
+It will end up at about 4ish resources per construct we want to support.  Not something really problematic,0,0.5
+Thanks @github and @github,0,0.5
 "I wanted to avoid ""Rename"" terminology to leave it open ended for things like file addition or movement. While moving a file _is_ a rename as far as full path is concerned, it's harder to convey that information. Maybe if we move to a service it could be #code (terrible name, but gets my point across)",0,0.5
-Feels a little gross with it being just in the root namespace and not putting it lower like #code or something... but if we want to leave it here since #code was a bare one anyway... I'm not going to complain that hard.,0,0.5
-That's a shame. I used to like having the panel and side bar next to each other with the code pushed all the way left.,0,0.5
+Feels a little gross with it being just in the root namespace and not putting it lower like #code or something... but if we want to leave it here since #code was a bare one anyway... I'm not going to complain that hard,0,0.5
+That's a shame. I used to like having the panel and side bar next to each other with the code pushed all the way left,0,0.5
 "So @github let me get this right - you have ""improved"" the code by removing functionality that a lot of users (including me) were happy with? For ... reasons? Thanks 🙄 Who exactly came to the unilateral decisions that the terminal can only be on the side opposite the file browser? wtf",0,0.5
 "Sometimes I wish MS could just leave the thing alone, I am happy with the way it works, why constantly ""enhance"" it and confuse your users... we got work to do. I guess I'll now go and spend a couple of hours of my time reading up on what the shiny new ""Side Panel"" behaviour and ""Terminal Editors"" are... 😡",0,0.5
 EDIT: I have read up on panels and terminal editors... it's an over complicated mess. Why have two different abstractions that do the same thing. Why force the users to get involved in understanding those concepts and configuring them. Basically you are trying to recreate Eclipse. Jesus. I miss the days when VSCode Just Worked,0,0.5
-this remains gloriously insane.,0,0.5
+this remains gloriously insane,0,0.5
 "This is, unfortunately, how #code types work. There can only be one active value, unless you do explicit work to make it support multiple values.",0,0.5
 "Well, TIL I am stupid. Sorry, for wasting your time.",1,0.5
 Fixing code soon™,0,0.5
 "@github reordering them would certainly be a better choice, but it isn't trivial for me, as I'm no expert in the details of how the JIT really works. As the reverse p/invoke is added to the prolog/epilog in the flowgraph stage, and the inlined call frame logic is handled during lower; however, I'm not comfortable making such a change myself, as the fix looked to be more involved than I was prepared to handle, and prolog/epilog code is notoriously fussy to get right. That said, if this gets checked in in the current state, I'll open an issue against the JIT team to look at coming up with the more optimal fix. I've been able to get this to reproduce reliably by running the determinism test in a loop under jitstress1 mode, so verifying a more complex fix is not a difficult task.",0,0.5
 "@github Rare is possibly the wrong word.... possibly, less common would be a better term. There are certainly scenarios in which the reverse pinvoke to pinvoke logic is in the same function, but I don't see that its all THAT common. (Also, the penalty from using the helper functions isn't terrible.) I'm pretty sure that we don't have significant test coverage of this scenario in our test beds as the characteristic assertion messages are quite rare.",0,0.5
 "I’m not sure if I’m qualified to speak with authority, but LLVM libunwind for ARM a bit undeveloped. Overall code looks like it is half done. I was able only fix gross issue like this https://github.com/llvm/llvm-project/commit/08a5ac36b956edeb989b4a65269a829eac26a5a2 In EHABI handling. For me this code is a bit scary",0,0.5
-Gross. Even in Kestrel.Core! 😭 I think I should have made you put those methods in KestrelTrace.,1,0.5
-Clearly we're inconsistent with whether we use extension methods on #code for structured logging or not. I vote for not using extension methods for this purpose going forward.,0,0.5
+Gross. Even in Kestrel.Core! 😭 I think I should have made you put those methods in KestrelTrace,1,0.5
+Clearly we're inconsistent with whether we use extension methods on #code for structured logging or not. I vote for not using extension methods for this purpose going forward,0,0.5
 "On an unrelated note, it looks like the consumers of Kestrel's LoggerExtensions are logging to #code instead of #code like the rest of the Kestrel.Core assembly. I guess at least we don't have EventId conflicts that way... Do you think it's worth consolidating these namespaces before 3.0, or is it not worth the break?",0,0.5
 "Or like one of my other suggestions, disallow this entirely and get users to use the endpoint routing authorization extensions: https://github.com/aspnet/AspNetCore/blob/16a47948f80fede807fabe3c291d793590e8fd17/src/Security/Authorization/Policy/src/AuthorizationEndpointConventionBuilderExtensions.cs#L14",0,0.5
 "While #code is old API, the endpoint routing based extension methods are new. It doesn't seem terrible to say this feature does not work when using endpoint routing. We could also use the Startup analyzer to guide users to not use this property.",0,0.5
-WTF is this?,1,0.5
-.... Because I clearly wrote this with very little to no sleep 😅 yea wtf was I thinking.,1,0.5
+WTF is this,1,0.5
+.... Because I clearly wrote this with very little to no sleep 😅 yea wtf was I thinking,1,0.5
 "Do we want to search for callers in the whole solution, or do we want to only search for them in the current document? Solution-wide is more difficult, but doable if we really want to.",0,0.5
-Ugh. I'd assume this is going to need to be solution wide. I personally don't think we should be altering call-sites all that much but that isn't a popular opinion.,0,0.5
+Ugh. I'd assume this is going to need to be solution wide. I personally don't think we should be altering call-sites all that much but that isn't a popular opinion,0,0.5
 "We do warn the user if we can't change all of the call-sites, so the experience isn't terrible. I'm fine holding off on this work until we get feedback that document-wide isn't enough.",0,0.5
-is throwing after unmarshalling okay?,0,0.5
+is throwing after unmarshalling okay,0,0.5
 "That can get tricky. This requires the state of the outs to be valid and that isn't always the case for out params of native functions. I can recall hitting older Win32 APIs that left outs in a dubious state, but I doubt that is any issue any longer.",0,0.5
-I think we'll hold off on adding a custom marshaller then until we get feedback that there's APIs that don't work correctly with the new ordering.,0,0.5
+I think we'll hold off on adding a custom marshaller then until we get feedback that there's APIs that don't work correctly with the new ordering,0,0.5
 "I'm fairly certain this code is pretty terrible.  However, i'm going to leave things as is so that we don't subtly break anything in 15.3",1,0.5
 "The commenting out does look gross, I'm OK deleting it 😄",1,0.5
-"Oh crap I'm so sorry @github 😢 , I didn't refresh my tab this morning when I replied to this thread so I didn't see the #code comment before pushing my wacky change! Both of you are totally right, it's a much better approach 😅",0,0.5
+"Oh crap I'm so sorry @github 😢, I didn't refresh my tab this morning when I replied to this thread so I didn't see the #code comment before pushing my wacky change! Both of you are totally right, it's a much better approach 😅",0,0.5
 "Oooof. Might need to add this back to fix #11285, to make sure that we have some acrylic on win10. Gross.",0,0.5
 "Previously, when a pull request's head branch was merged and deleted, all other open pull requests in the same repository with a base branch of the merged branch would be automatically closed.",0,0.5
 "Now, instead of automatically closing these open pull requests, the pull requests will be retargeted—the base branch of each pull request will be updated to the merged pull request's base branch.",0,0.5
 wtf,1,0.5
-Those aren't terrible ideas at all! :smile:,0,0.5
+Those aren't terrible ideas at all! :smile,0,0.5
 "I think you already had some sort of ""context"" object that was beginning to congeal. Perhaps a type that is the ""context"" that contains the trigger, various ""environment"" flags (notably this debugger flag and the interactive flag), and maybe some other pieces of information could become the replacement.",0,0.5
 "This would need to be a _yet another_ type than the ""context"" object that is passed by the completion service to #code. I'd prefer not to introduce more of these. However, your point is taken. I was modeling CustomTags off of what we did with diagnostics, but perhaps that's not the best approach here.",0,0.5
 "Is the debugger flag only being used to control whether we list completion items before their declaration point? And do completion providers get passed an OptionSet from the originating workspace (or can get at it)? If both are ""yes"", then perhaps we should instead have there be a not-UI-exposed completion option that simply specifies that debugger behavior, and the debugger workspace we create just sets that option explicitly. I could imagine people might actually like that behavior during real typing as well. It's not rare that you might write some code and realize you need to use a local declared farther down. Rather than me breaking context, moving the local up, and then writing the code again, that it's perhaps OK to actually complete it anyways. It's I am not saying we should expose it in a UI (at least not until customers come with pitchforks asking for it :smile:), but if they did come along and ask for that we'd implement that with an option. Given that also might fix this problem too, I can't help but notice the coincidence.",0,0.5
@@ -2306,42 +2308,42 @@ Those aren't terrible ideas at all! :smile:,0,0.5
 "Workspace kind is a pretty big hammer that I'd like to avoid. Of course, you probably listed it last because you'd like me to avoid it too. :smile:",0,0.5
 "wtf.... what on earth is this skip-while for?!  That's just crazy.  I'd much rather remove this code, and fix whatever issue it was trying to work around.",1,0.5
 @github could you please explain what you mean by,0,0.5
-It's also designed to be (partially) AOT friendly by making the core icall not generic.,0,0.5
+It's also designed to be (partially) AOT friendly by making the core icall not generic,0,0.5
 "At one point we had an invoke icall with a generic ``#code`#codemono_wasm_invoke_js#codeeval#codeEM_ASM_INT#code`#code`#code`#code`#code`#code``, the overhead of looking up the string literal is nonzero (especially because it's not required to be interned), and not being able to pass arguments requires the caller to do unclean things like shove arguments into globals (which is not a cheap thing to do via the current API... you'd have to do SetObjectProperty per-argument.)",0,0.5
 "My endgame for this is that we use source generators to create strongly-typed wrappers for specific methods (JS pinvoke, basically) that correctly and efficiently use this new icall under the hood. Later on those wrappers could transition to using dedicated JS and bypassing the icall machinery if necessary.",0,0.5
 "Stupid question, but shouldn't expanding the nav bar block until it's ready anyway?",0,0.5
-Async methods can't be conditioned? WTF.,1,0.5
+Async methods can't be conditioned? WTF,1,0.5
 okay that's _insane_ but I can deal with it,1,0.5
 "I'm not yet familiar with the regex handoffs between TS and ripgrep—would ripgrep have to support the same case change operations, or is TS performing the replacement and ripgrep is more of a file buffer, match-only iterator?",0,0.5
 "A String.replace() replacer() function defeats the internal parameter handling AFAICT, which means that the replacer has to walk the replacement pattern character at a time and replace the various $N instances. This isn't hugely challenging but it's very reinvent-the-wheel-y and duplicates a lot of the work and logic I see in #code.",0,0.5
 "So while I agree the second sounds easier, it also feels like it's fairly significantly increasing the difference between these fundamentally identical code paths. The current codepath is already applying the regex twice, once into #code and once with he #codees.",0,0.5
 "Moving the vs/editor/contrib/find logic to vs/base/common might be the best use of time, even if it delays the case ops support. Just IMHO, still very much a noob to this codebase.",0,0.5
-An HTML tag can’t begin inside the attributes of another HTML tag.,0,0.5
+An HTML tag can’t begin inside the attributes of another HTML tag,0,0.5
 // We always pass the output through insane after this so that we don't rely on,0,0.5
-// marked for sanitization.,0,0.5
+// marked for sanitization,0,0.5
 I'm not sure that [^>] is correct. We still want to prevent html tags,0,0.5
-from beginning. [^<>] would probably be the best.,0,0.5
-You are receiving this because you authored the thread.,0,0.5
+from beginning. [^<>] would probably be the best,0,0.5
+You are receiving this because you authored the thread,0,0.5
 "Reply to this email directly, view it on GitHub",0,0.5
 WTF,1,0.5
 That's about our reaction :). Seems like it might be DI flakiness that just hit Negotiate tests (so the quarantine might not be super effective 🤷‍♀),0,0.5
-"Yeah that is fine , we have been doing it so far and nothing terrible happened :)",0,0.5
+"Yeah that is fine, we have been doing it so far and nothing terrible happened :)",0,0.5
 "But my followup work plan is to extract the crash reporter configuration as a separate CrashReporterService interface that can be shared by main, renderer and extension host, that way each can start the reporter at their convenience and share the base config.",0,0.5
-@github - what a nasty user :blush: I believe that the problem you describe exists in the original code as well.,0,0.5
+@github - what a nasty user :blush: I believe that the problem you describe exists in the original code as well,0,0.5
 "From my understanding,  If the user triggers delayed sleep and then starts switching, what will happen right now is that we will still have TabPaletteItem populated in the switcher, but switching to it will have no action (as weak ref is empty). Not perfect, not terrible (or however they said this in Chernobyl). To resolve this we need to have the fully fledged binding that I planned for the next PR (where we do follow the changes in _tabs, _mruTabs that are observable collections).",0,0.5
 yea this looks insane as-is haha,1,0.5
-Holy shit this is legendary. This has been my biggest pain point on Windows for many many years (remote tmux sessions were always garbled). Thank you!!!,0,0.5
+Holy shit this is legendary. This has been my biggest pain point on Windows for many many years (remote tmux sessions were always garbled). Thank you,0,0.5
 "I'm stupid, I wanted to do the opposite 🤦‍♂",1,0.5
-Do we trust people not doing 'stupid' things like Static etc..?,1,0.5
+Do we trust people not doing 'stupid' things like Static etc,1,0.5
 "Can you fold the previous #code into part of the loop and iterate over 4 times? If it gets too gross, don't worry about it",0,0.5
-stupid question: why isn't #code instead of #code?,0,0.5
+stupid question: why isn't #code instead of #code,0,0.5
 Tagging subscribers to 'arch-wasm': @github,0,0.5
-See info in area-owners.md if you want to be subscribed.,0,0.5
+See info in area-owners.md if you want to be subscribed,0,0.5
 "To get good behavior in typescript, your enums need to be 'const enum', otherwise it generates some really gross JS with runtime overhead. I didn't know this (thanks to @github for the tip)",0,0.5
 "Just to check, there's some terrible reason why the newer tools don't work against Preview 5? And if that file that it cant find is new since Preview 5, I think we just spotted your version check. ;-)",0,0.5
 "This reduces terms like ""Looper"" (""wtf is a looper!""), replacing with a (hopefully?) more common term of ""message loop"", and also provides the callback method that won't be invoked. This should hopefully be useful for debugging/diagnostics.",1,0.5
-I think this implementation is terrible. Need more investigate and discussion.,1,0.5
-Thank you for your review.,0,0.5
+I think this implementation is terrible. Need more investigate and discussion,1,0.5
+Thank you for your review,0,0.5
 Sorry again,0,0.5
 "@github please excuse me if this is a stupid question, but how do our CI runs the WASM unit tests? Are they being executed on dedicated mobile devices or are we using V8 and running them on a VM? I am asking because I would like to repro the failure and according to my research, I should follow [these](https://github.com/dotnet/runtime/blob/main/docs/workflow/testing/libraries/testing-wasm.md#running-individual-test-suites-using-javascript-engine) instructions.",0,0.5
 "Also: I am experiencing a timeout, what could have possibly caused it? The tests are single-threaded FWIW.",0,0.5

--- a/onnxjs/tests/onnx.ts
+++ b/onnxjs/tests/onnx.ts
@@ -8,14 +8,14 @@ describe('onnx tests', async () => {
 
     const githubHandleRegex:RegExp = /\B@([a-z0-9](?:-(?=[a-z0-9])|[a-z0-9]){0,38}(?<=[a-z0-9]))/gi;
     const backtickRegex:RegExp = /`+[^`]+`+/gi;
-    const punctuationRegex:RegExp = /(\.|!|\?)+$/g;
+    const punctuationRegex:RegExp = /(\.|!|\?|;|:)+$/g;
 
     async function assertText(text:string, isnegative:string, confidence:number) {
         const github_replaced = text.replace(githubHandleRegex, '@github');
         const backtick_replaced = github_replaced.replace(backtickRegex, '#code');
         const punctuation_replaced = backtick_replaced.replace(punctuationRegex, '');
         const results = await session.run({
-            text: new ort.Tensor([punctuation_replaced], [1,1]),
+            text: new ort.Tensor([punctuation_replaced.trim()], [1,1]),
             isnegative: new ort.Tensor([''], [1,1]),
             importance: new ort.Tensor('float32', [''], [1,1]),
         })

--- a/onnxjs/tests/test_cases.json
+++ b/onnxjs/tests/test_cases.json
@@ -56,7 +56,7 @@
         "isnegative": "1"
     },
     {
-        "text": "Your code is a nightmare",
+        "text": "Your code is a nightmare !!!!",
         "isnegative": "1"
     },
     {


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/pull/143
Context: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/123

We've found that adding a `.`, `:`, etc. can influence the results of the machine learning model. Let's trim out trailing punctuation to solve this.

I manually replaced lines in our dataset as well.