### PR TITLE
[MLTrainer] Add keyboard support to classify comments

### DIFF
--- a/Maui/MLTrainer/App.xaml.cs
+++ b/Maui/MLTrainer/App.xaml.cs
@@ -6,6 +6,6 @@ public partial class App : Application
 	{
 		InitializeComponent();
 
-		MainPage = new AppShell();
+		MainPage = new AppShell(new ViewModels.ClassificationViewModel());
 	}
 }

--- a/Maui/MLTrainer/AppShell.xaml.cs
+++ b/Maui/MLTrainer/AppShell.xaml.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.UI.Xaml;
-
-namespace MLTrainer;
+﻿namespace MLTrainer;
 
 public partial class AppShell : Shell
 {
@@ -14,27 +12,24 @@ public partial class AppShell : Shell
 	protected override void OnNavigated(ShellNavigatedEventArgs args)
 	{
 		base.OnNavigated(args);
-
+#if WINDOWS
 		Window.Activated += AppShellActivated;
 		Window.Deactivated += AppShellDeactivated;
 	}
 
 	void AppShellDeactivated(object? sender, EventArgs e)
 	{
-#if WINDOWS
+
 		MauiWinUIWindow? win = Window.Handler.PlatformView as MauiWinUIWindow;
 		if (win?.Content != null)
 			win.Content.KeyDown -= ContentKeyDown;
-#endif
 	}
 
 	void AppShellActivated(object? sender, EventArgs e)
 	{
-#if WINDOWS
 		MauiWinUIWindow? win = Window.Handler.PlatformView as MauiWinUIWindow;
 		if (win?.Content != null)
 			win.Content.KeyDown += ContentKeyDown;
-#endif
 	}
 
 	void ContentKeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
@@ -52,4 +47,7 @@ public partial class AppShell : Shell
 			_classificationViewModel.SkipCommentCommand.Execute(null);
 		}
 	}
+#else
+	}
+#endif
 }

--- a/Maui/MLTrainer/AppShell.xaml.cs
+++ b/Maui/MLTrainer/AppShell.xaml.cs
@@ -1,9 +1,55 @@
-﻿namespace MLTrainer;
+﻿using Microsoft.UI.Xaml;
+
+namespace MLTrainer;
 
 public partial class AppShell : Shell
 {
-	public AppShell()
+	ViewModels.ClassificationViewModel _classificationViewModel;
+	public AppShell(ViewModels.ClassificationViewModel classificationViewModel)
 	{
 		InitializeComponent();
+		BindingContext = _classificationViewModel = classificationViewModel;
+	}
+
+	protected override void OnNavigated(ShellNavigatedEventArgs args)
+	{
+		base.OnNavigated(args);
+
+		Window.Activated += AppShellActivated;
+		Window.Deactivated += AppShellDeactivated;
+	}
+
+	void AppShellDeactivated(object? sender, EventArgs e)
+	{
+#if WINDOWS
+		MauiWinUIWindow? win = Window.Handler.PlatformView as MauiWinUIWindow;
+		if (win?.Content != null)
+			win.Content.KeyDown -= ContentKeyDown;
+#endif
+	}
+
+	void AppShellActivated(object? sender, EventArgs e)
+	{
+#if WINDOWS
+		MauiWinUIWindow? win = Window.Handler.PlatformView as MauiWinUIWindow;
+		if (win?.Content != null)
+			win.Content.KeyDown += ContentKeyDown;
+#endif
+	}
+
+	void ContentKeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
+	{
+		if (e.Key == Windows.System.VirtualKey.Left)
+		{
+			_classificationViewModel.BadCommentCommand.Execute(null);
+		}
+		if (e.Key == Windows.System.VirtualKey.Right)
+		{
+			_classificationViewModel.GoodCommentCommand.Execute(null);
+		}
+		if (e.Key == Windows.System.VirtualKey.Space)
+		{
+			_classificationViewModel.SkipCommentCommand.Execute(null);
+		}
 	}
 }

--- a/Maui/MLTrainer/Views/ClassificationView.xaml
+++ b/Maui/MLTrainer/Views/ClassificationView.xaml
@@ -47,7 +47,8 @@
                 VerticalOptions="Center"
                 FontSize="30"/>
 
-        <Button Text="Bad Comment"
+        <Button Text="Bad Comment (left arrow)"
+                
                 Command="{Binding BadCommentCommand}"
                 BackgroundColor="Red"
                 IsEnabled="False"
@@ -75,7 +76,7 @@
             </CollectionView.ItemTemplate>
         </CollectionView>-->
 
-        <Button Text="Good Comment"
+        <Button Text="Good Comment (right arrow)"
                 Command="{Binding GoodCommentCommand}"
                 BackgroundColor="Green"
                 FontSize="20"
@@ -85,12 +86,16 @@
 
 
         <Button Grid.Row="3" Grid.Column="1"
-                Text="Skip"
+                Text="Skip (space)"
                 SemanticProperties.Hint="Skip"
                 Command="{Binding SkipCommentCommand}"
                 HorizontalOptions="Center"
                  VerticalOptions="Center"
                 FontSize="30"/>
+
+        <Label Text="You can use your keyboard to classify or skip comments. Left arrow for a bad comment. Right arrow for a good comment and Space to skip the comment"
+               Grid.Row="3" Grid.Column="2"
+               HorizontalOptions="End"/>
 
     </Grid>
 </ContentView>

--- a/Maui/MLTrainer/Views/ClassificationView.xaml.cs
+++ b/Maui/MLTrainer/Views/ClassificationView.xaml.cs
@@ -6,6 +6,6 @@ public partial class ClassificationView : ContentView
 	{
 		InitializeComponent();
 
-		BindingContext = App.Current?.Handler?.MauiContext?.Services.GetService<ViewModels.ClassificationViewModel>();
+	
 	}
 }


### PR DESCRIPTION
Allow to use keyboard to classify comments faster. 

Left key will do a bad comment, right key will classify as a good comment, and space will skip the comment.


<img width="1423" alt="image" src="https://user-images.githubusercontent.com/1235097/191587825-72649334-98e9-4b95-9158-aa0a7f443ced.png">
