### PR TITLE
Allow phrases like "deleted:"

### DIFF
--- a/comments/classified.csv
+++ b/comments/classified.csv
@@ -155,6 +155,12 @@ This is awful,1,0.5
 You are awful,1,0.5
 This is confusing,1,0.5
 This is confusing code,1,0.5
+"Deleted: an unused class, #code, and two unused methods",0,0.5
+I deleted the following,0,0.5
+I deleted #code,0,0.5
+Deleted #code and #code,0,0.5
+Deleted,0,0.5
+"Deleted, thanks",0,0.5
 Delete this confusing code,1,0.5
 Delete this code immediately,1,0.5
 This should be deleted immediately,1,0.5

--- a/onnxjs/tests/test_cases.json
+++ b/onnxjs/tests/test_cases.json
@@ -334,5 +334,18 @@
     {
         "text": "This is cool.",
         "isnegative": "0"
+    },
+    {
+        "text": "Deleted:",
+        "isnegative": "0",
+        "notes": "The idea on this one, is you have a bulleted-list mentioning what you deleted."
+    },
+    {
+        "text": "I don't like this delete it",
+        "isnegative": "1"
+    },
+    {
+        "text": "Delete all of this junk",
+        "isnegative": "1"
     }
 ]


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/167

The idea is you might write something like:

    Deleted:
    * ABC
    * XYZ