### PR TITLE
Better detect "you are stupid"

### DIFF
--- a/comments/classified.csv
+++ b/comments/classified.csv
@@ -4936,3 +4936,7 @@ When you're this good,0,0.5
 "Hi @github, glad to hear from you",0,0.5
 "Hello Chuck",0,0.5
 "Hello @github",0,0.5
+Setting up such a configuration means you are stupid,1,0.5
+asking to build with such configuration means you are stupid,1,0.5
+Code looks great (but doesn't mean you aren't stupid),1,0.5
+You are stupid,1,0.5

--- a/onnxjs/tests/test_cases.json
+++ b/onnxjs/tests/test_cases.json
@@ -411,5 +411,9 @@
     {
         "text": "Hi Chuck,",
         "isnegative": "0"
+    },
+    {
+        "text": "(\"technically\" it is not a \"must\", but asking to build with such configuration means you are stupid)",
+        "isnegative": "1"
     }
 ]


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-reviews-ml/issues/126

I think we had lots of examples of "I'm stupid", and so it wasn't catching things like "You're stupid".