### PR TITLE
[maui] use $(MauiVersion)

### DIFF
--- a/.github/workflows/maui.yml
+++ b/.github/workflows/maui.yml
@@ -34,7 +34,6 @@ jobs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 8.x
-        include-prerelease: true
 
     - name: Install MAUI Workloads
       run: dotnet workload install maui-desktop --ignore-failed-sources

--- a/Maui/MLTrainer/MLTrainer.csproj
+++ b/Maui/MLTrainer/MLTrainer.csproj
@@ -53,7 +53,7 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" />
 		<PackageReference Include="CsvHelper" />
-    <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.0-rc.2.9511" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 	</ItemGroup>
 	
 </Project>


### PR DESCRIPTION
Just to use the same version as the workload that is installed.

We can also stop using prerelease .NET.