### PR TITLE
[actions] skip macos in maui.yml

### DIFF
--- a/.github/workflows/maui.yml
+++ b/.github/workflows/maui.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-12, windows-2022]
+        os: [windows-2022]
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }}


### PR DESCRIPTION
This fails, I think we need to pick a newer macos.

Let's just disable for now.